### PR TITLE
[Feat] Implement worktree hook execution with real-time output

### DIFF
--- a/cmd/worktree_test.go
+++ b/cmd/worktree_test.go
@@ -47,6 +47,35 @@ func TestRunWorktreeDefault_ShowsWorktreesInNonBareRepo(t *testing.T) {
 	assert.NotContains(t, output, "not using the bare worktree pattern")
 }
 
+func TestWtHookRemoveCmd_RejectsTrailingCharactersInIndex(t *testing.T) {
+	repoDir := initCmdTestRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), []byte("hooks:\n  - cmd: echo ok\n"), 0o644))
+
+	oldCwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldCwd) }()
+	require.NoError(t, os.Chdir(repoDir))
+
+	var out bytes.Buffer
+	oldOut := outWriterFunc
+	oldErr := errWriterFunc
+	outWriterFunc = func() io.Writer { return &out }
+	errWriterFunc = func() io.Writer { return &out }
+	defer func() {
+		outWriterFunc = oldOut
+		errWriterFunc = oldErr
+	}()
+
+	err = wtHookRemoveCmd.RunE(wtHookRemoveCmd, []string{"1abc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid hook index")
+
+	client := worktree.NewClient(worktree.Options{})
+	cfg, _, err := client.LoadSharedConfig()
+	require.NoError(t, err)
+	require.Len(t, cfg.Hooks, 1)
+}
+
 func initCmdTestRepo(t *testing.T) string {
 	t.Helper()
 	repoDir := t.TempDir()

--- a/internal/worktree/resource.go
+++ b/internal/worktree/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -23,6 +24,11 @@ type SharedResource struct {
 	Strategy ResourceStrategy `yaml:"strategy"`
 }
 
+type Hook struct {
+	Cmd  string `yaml:"cmd"`
+	Desc string `yaml:"desc,omitempty"`
+}
+
 const (
 	sharedConfigName       = "gmc-share.yml"
 	legacySharedConfigYML  = ".gmc-shared.yml"
@@ -31,6 +37,7 @@ const (
 
 type SharedConfig struct {
 	Resources []SharedResource `yaml:"shared"`
+	Hooks     []Hook           `yaml:"hooks,omitempty"`
 }
 
 func (c *Client) SyncSharedResources(worktreeName string) (Report, error) {
@@ -41,10 +48,10 @@ func (c *Client) SyncSharedResources(worktreeName string) (Report, error) {
 		return report, err
 	}
 
-	return c.syncSharedResourcesToPath(targetRoot)
+	return c.syncSharedResourcesToPath(targetRoot, true)
 }
 
-func (c *Client) syncSharedResourcesToPath(targetRoot string) (Report, error) {
+func (c *Client) syncSharedResourcesToPath(targetRoot string, runHooks bool) (Report, error) {
 	var report Report
 
 	cfg, _, err := c.LoadSharedConfig()
@@ -52,7 +59,7 @@ func (c *Client) syncSharedResourcesToPath(targetRoot string) (Report, error) {
 		return report, err
 	}
 
-	if len(cfg.Resources) == 0 {
+	if len(cfg.Resources) == 0 && (!runHooks || len(cfg.Hooks) == 0) {
 		return report, nil
 	}
 
@@ -68,6 +75,13 @@ func (c *Client) syncSharedResourcesToPath(targetRoot string) (Report, error) {
 			return report, err
 		}
 	}
+
+	if runHooks {
+		if err := c.runHooks(targetRoot, cfg.Hooks, &report); err != nil {
+			return report, err
+		}
+	}
+
 	return report, nil
 }
 
@@ -268,6 +282,59 @@ func (c *Client) RemoveSharedResource(path string) (Report, error) {
 	return report, nil
 }
 
+func (c *Client) AddHook(hook Hook) (Report, error) {
+	var report Report
+
+	if hook.Cmd == "" {
+		return report, errors.New("hook command cannot be empty")
+	}
+
+	cfg, configPath, err := c.LoadSharedConfig()
+	if err != nil {
+		return report, err
+	}
+
+	cfg.Hooks = append(cfg.Hooks, hook)
+
+	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
+		return report, err
+	}
+
+	desc := hook.Desc
+	if desc == "" {
+		desc = hook.Cmd
+	}
+	report.Info(fmt.Sprintf("Added hook: %s", desc))
+	return report, nil
+}
+
+func (c *Client) RemoveHook(index int) (Report, error) {
+	var report Report
+
+	cfg, configPath, err := c.LoadSharedConfig()
+	if err != nil {
+		return report, err
+	}
+
+	if index < 0 || index >= len(cfg.Hooks) {
+		return report, fmt.Errorf("hook index %d out of range (total: %d)", index, len(cfg.Hooks))
+	}
+
+	removed := cfg.Hooks[index]
+	cfg.Hooks = append(cfg.Hooks[:index], cfg.Hooks[index+1:]...)
+
+	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
+		return report, err
+	}
+
+	desc := removed.Desc
+	if desc == "" {
+		desc = removed.Cmd
+	}
+	report.Info(fmt.Sprintf("Removed hook: %s", desc))
+	return report, nil
+}
+
 func (c *Client) SyncAllSharedResources() (Report, error) {
 	var report Report
 
@@ -298,7 +365,7 @@ func (c *Client) SyncAllSharedResources() (Report, error) {
 
 	report.Info(fmt.Sprintf("Syncing resources to %d worktrees...", len(targets)))
 	for _, wt := range targets {
-		resourceReport, err := c.syncSharedResourcesToPath(wt.Path)
+		resourceReport, err := c.syncSharedResourcesToPath(wt.Path, false)
 		report.Merge(resourceReport)
 		if err != nil {
 			report.Warn(fmt.Sprintf("Warning: failed to sync %s: %v", filepath.Base(wt.Path), err))
@@ -518,4 +585,33 @@ func copyDir(src, dst string) error {
 
 		return copyFile(path, destPath)
 	})
+}
+
+func (c *Client) runHooks(worktreeRoot string, hooks []Hook, report *Report) error {
+	if len(hooks) == 0 {
+		return nil
+	}
+
+	for _, hook := range hooks {
+		if hook.Cmd == "" {
+			continue
+		}
+
+		label := hook.Cmd
+		if hook.Desc != "" {
+			label = hook.Desc
+		}
+		report.Info(fmt.Sprintf("Running hook: %s", label))
+
+		cmd := exec.Command("sh", "-c", hook.Cmd)
+		cmd.Dir = worktreeRoot
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("hook failed '%s': %w", hook.Cmd, err)
+		}
+	}
+
+	return nil
 }

--- a/internal/worktree/resource_nonbare_test.go
+++ b/internal/worktree/resource_nonbare_test.go
@@ -53,6 +53,31 @@ func TestSyncAllSharedResources_WorksFromNonBareWorktreeRepo(t *testing.T) {
 	assert.Equal(t, "SECRET=123", string(data))
 }
 
+func TestSyncAllSharedResources_DoesNotRunHooks(t *testing.T) {
+	repoDir := initTestRepo(t)
+	linkedWt := filepath.Join(t.TempDir(), "feature-wt")
+	runGit(t, repoDir, "worktree", "add", "-b", "feature/test-sync-hooks", linkedWt, "main")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".env"), []byte("SECRET=123"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), []byte("shared:\n  - path: .env\n    strategy: copy\nhooks:\n  - cmd: printf 'hook-ran' > hook.txt\n"), 0o644))
+
+	client := NewClient(Options{})
+	oldCwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldCwd) }()
+	require.NoError(t, os.Chdir(linkedWt))
+
+	_, err = client.SyncAllSharedResources()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(linkedWt, ".env"))
+	require.NoError(t, err)
+	assert.Equal(t, "SECRET=123", string(data))
+
+	_, err = os.Stat(filepath.Join(linkedWt, "hook.txt"))
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestLoadSharedConfig_FallsBackToLegacyRepoRootConfig(t *testing.T) {
 	repoDir := initTestRepo(t)
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, legacySharedConfigYML), []byte("shared:\n  - path: .env\n    strategy: copy\n"), 0o644))


### PR DESCRIPTION
### What's changed?

- Add `Hook` struct, `SharedConfig.Hooks` field, and `AddHook`/`RemoveHook` methods in `internal/worktree/resource.go`
- Implement `runHooks` engine that streams stdout/stderr to terminal in real time (replaces `CombinedOutput` which buffered all output until completion)
- Hooks execute after shared resource sync on `wt add`; skipped during `wt share sync` bulk operations
- Add tests for hook remove validation and sync-without-hooks behavior

### Why

- Hook commands like `pnpm install` can take a long time; users had zero visibility into progress, making the tool appear frozen
- Streaming output gives immediate feedback during hook execution