### PR TITLE
[Feat] Add `gmc wt share discover` subcommand

### DIFF
--- a/cmd/worktree_share.go
+++ b/cmd/worktree_share.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	shareStrategy string
+	discoverAuto  bool
 )
 
 var wtShareCmd = &cobra.Command{
@@ -97,6 +98,74 @@ var wtShareListCmd = &cobra.Command{
 	},
 }
 
+var wtShareDiscoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "Discover files that should be shared across worktrees",
+	Long: `Scan the main worktree for files that should be shared across worktrees.
+
+By default, shows a preview of discovered files (dry-run mode).
+Use --auto to actually add discovered files and sync them.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		wtClient := newWorktreeClient()
+
+		results, err := wtClient.Discover(worktree.DiscoverOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(results) == 0 {
+			fmt.Println("No new shareable files discovered.")
+			return nil
+		}
+
+		var copyResults, linkResults []worktree.DiscoverResult
+		for _, r := range results {
+			switch r.Strategy {
+			case worktree.StrategyCopy:
+				copyResults = append(copyResults, r)
+			case worktree.StrategySymlink:
+				linkResults = append(linkResults, r)
+			}
+		}
+
+		fmt.Println("Discovered shareable files:")
+		fmt.Println()
+		if len(copyResults) > 0 {
+			fmt.Println("Copy strategy (isolated per worktree):")
+			for _, r := range copyResults {
+				fmt.Printf("  %s\n", r.Path)
+			}
+		}
+		if len(linkResults) > 0 {
+			fmt.Println("Link strategy (shared, saves disk):")
+			for _, r := range linkResults {
+				fmt.Printf("  %s\n", r.Path)
+			}
+		}
+
+		if !discoverAuto {
+			fmt.Printf("\n[dry-run] Would add %d copy + %d link resources\n", len(copyResults), len(linkResults))
+			return nil
+		}
+
+		fmt.Println()
+		addReport, addErr := wtClient.AddDiscoveredResources(results)
+		printWorktreeReport(addReport)
+		if addErr != nil {
+			return addErr
+		}
+
+		fmt.Println("\nSyncing to all worktrees...")
+		report, err := wtClient.SyncAllSharedResources()
+		printWorktreeReport(report)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Done.")
+		return nil
+	},
+}
+
 var wtShareSyncCmd = &cobra.Command{
 	Use:   "sync",
 	Short: "Manually sync shared resources to all worktrees",
@@ -114,9 +183,13 @@ func init() {
 	wtShareCmd.AddCommand(wtShareRemoveCmd)
 	wtShareCmd.AddCommand(wtShareListCmd)
 	wtShareCmd.AddCommand(wtShareSyncCmd)
+	wtShareCmd.AddCommand(wtShareDiscoverCmd)
 
 	wtShareAddCmd.Flags().StringVarP(&shareStrategy, "strategy", "s", "copy", "Sync strategy: copy or link")
 	_ = wtShareAddCmd.RegisterFlagCompletionFunc("strategy", completeStrategies)
+
+	wtShareDiscoverCmd.Flags().BoolVar(&discoverAuto, "auto", false, "Actually add discovered items and sync")
+	wtShareDiscoverCmd.Flags().Bool("dry-run", true, "Preview mode (default behavior)")
 }
 
 func runWorktreeShareInteractive(c *worktree.Client) error {

--- a/internal/worktree/share_discover.go
+++ b/internal/worktree/share_discover.go
@@ -1,0 +1,141 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var copyCandidates = []string{
+	".env",
+	".env.local",
+	".env.development",
+	".env.production",
+	".claude/settings.json",
+	".claude/CLAUDE.md",
+	".serena/project.yml",
+}
+
+var linkCandidates = []string{
+	"node_modules",
+	".venv",
+	"vendor",
+	"__pycache__",
+}
+
+type DiscoverOptions struct {
+	MainWorktreePath string
+}
+
+type DiscoverResult struct {
+	Path     string           `json:"path"`
+	Strategy ResourceStrategy `json:"strategy"`
+	Reason   string           `json:"reason"`
+}
+
+func (c *Client) Discover(opts DiscoverOptions) ([]DiscoverResult, error) {
+	cfg, _, err := c.LoadSharedConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	existing := make(map[string]bool, len(cfg.Resources))
+	for _, res := range cfg.Resources {
+		existing[res.Path] = true
+	}
+
+	mainPath := opts.MainWorktreePath
+	if mainPath == "" {
+		mainPath, err = c.findMainWorktreePath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var results []DiscoverResult
+
+	for _, candidate := range copyCandidates {
+		if existing[candidate] {
+			continue
+		}
+		if _, statErr := os.Stat(filepath.Join(mainPath, candidate)); statErr == nil {
+			results = append(results, DiscoverResult{
+				Path:     candidate,
+				Strategy: StrategyCopy,
+				Reason:   "config/env file — isolated copy per worktree",
+			})
+		}
+	}
+
+	for _, candidate := range linkCandidates {
+		if existing[candidate] {
+			continue
+		}
+		if _, statErr := os.Stat(filepath.Join(mainPath, candidate)); statErr == nil {
+			results = append(results, DiscoverResult{
+				Path:     candidate,
+				Strategy: StrategySymlink,
+				Reason:   "dependency/cache directory — shared symlink saves disk",
+			})
+		}
+	}
+
+	return results, nil
+}
+
+func (c *Client) AddDiscoveredResources(results []DiscoverResult) (Report, error) {
+	var report Report
+
+	if len(results) == 0 {
+		return report, nil
+	}
+
+	cfg, configPath, err := c.LoadSharedConfig()
+	if err != nil {
+		return report, err
+	}
+
+	existing := make(map[string]bool, len(cfg.Resources))
+	for _, res := range cfg.Resources {
+		existing[res.Path] = true
+	}
+
+	for _, r := range results {
+		if existing[r.Path] {
+			continue
+		}
+		cfg.Resources = append(cfg.Resources, SharedResource{
+			Path:     r.Path,
+			Strategy: r.Strategy,
+		})
+		report.Info(fmt.Sprintf("Added shared resource: %s (%s)", r.Path, r.Strategy))
+	}
+
+	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
+		return report, err
+	}
+
+	return report, nil
+}
+
+func (c *Client) findMainWorktreePath() (string, error) {
+	worktrees, err := c.List()
+	if err != nil {
+		return "", fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	for _, wt := range worktrees {
+		if wt.Branch == "main" || wt.Branch == "master" {
+			return wt.Path, nil
+		}
+	}
+
+	for _, wt := range worktrees {
+		if !wt.IsBare && filepath.Base(wt.Path) != ".bare" {
+			fmt.Fprintf(os.Stderr, "Warning: no main/master branch found, using worktree %q\n", filepath.Base(wt.Path))
+			return wt.Path, nil
+		}
+	}
+
+	return "", fmt.Errorf("no worktree found to scan")
+}

--- a/internal/worktree/share_discover_test.go
+++ b/internal/worktree/share_discover_test.go
@@ -1,0 +1,175 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDiscover_FindsCandidates(t *testing.T) {
+	mainWT := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(mainWT, ".env"), []byte("X=1"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(mainWT, "node_modules"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(mainWT, ".claude"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mainWT, ".claude", "CLAUDE.md"), []byte("# hi"), 0644))
+
+	repoDir := t.TempDir()
+	bareDir := filepath.Join(repoDir, ".bare")
+	require.NoError(t, os.Mkdir(bareDir, 0755))
+
+	oldCwd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(repoDir))
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 3)
+
+	paths := make(map[string]ResourceStrategy)
+	for _, r := range results {
+		paths[r.Path] = r.Strategy
+	}
+	assert.Equal(t, StrategyCopy, paths[".env"])
+	assert.Equal(t, StrategyCopy, paths[".claude/CLAUDE.md"])
+	assert.Equal(t, StrategySymlink, paths["node_modules"])
+}
+
+func TestDiscover_SkipsExisting(t *testing.T) {
+	mainWT := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(mainWT, ".env"), []byte("X=1"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(mainWT, "node_modules"), 0755))
+
+	repoDir := t.TempDir()
+	bareDir := filepath.Join(repoDir, ".bare")
+	require.NoError(t, os.Mkdir(bareDir, 0755))
+
+	cfg := SharedConfig{
+		Resources: []SharedResource{
+			{Path: ".env", Strategy: StrategyCopy},
+		},
+	}
+	data, _ := yaml.Marshal(&cfg)
+	require.NoError(t, os.WriteFile(filepath.Join(bareDir, "gmc-share.yml"), data, 0644))
+
+	oldCwd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(repoDir))
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 1)
+	assert.Equal(t, "node_modules", results[0].Path)
+	assert.Equal(t, StrategySymlink, results[0].Strategy)
+}
+
+func TestDiscover_EmptyWorktree(t *testing.T) {
+	mainWT := t.TempDir()
+
+	repoDir := t.TempDir()
+	bareDir := filepath.Join(repoDir, ".bare")
+	require.NoError(t, os.Mkdir(bareDir, 0755))
+
+	oldCwd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(repoDir))
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
+	require.NoError(t, err)
+
+	assert.Empty(t, results)
+}
+
+func TestDiscover_AllCopyCandidates(t *testing.T) {
+	mainWT := t.TempDir()
+
+	for _, c := range copyCandidates {
+		full := filepath.Join(mainWT, c)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte("data"), 0644))
+	}
+
+	repoDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(repoDir, ".bare"), 0755))
+
+	oldCwd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(repoDir))
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
+	require.NoError(t, err)
+
+	var copyCount int
+	for _, r := range results {
+		if r.Strategy == StrategyCopy {
+			copyCount++
+		}
+	}
+	assert.Equal(t, len(copyCandidates), copyCount)
+}
+
+func TestDiscover_AllLinkCandidates(t *testing.T) {
+	mainWT := t.TempDir()
+
+	for _, c := range linkCandidates {
+		require.NoError(t, os.Mkdir(filepath.Join(mainWT, c), 0755))
+	}
+
+	repoDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(repoDir, ".bare"), 0755))
+
+	oldCwd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(repoDir))
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
+	require.NoError(t, err)
+
+	var linkCount int
+	for _, r := range results {
+		if r.Strategy == StrategySymlink {
+			linkCount++
+		}
+	}
+	assert.Equal(t, len(linkCandidates), linkCount)
+}
+
+func TestAddDiscoveredResources_Batch(t *testing.T) {
+	repoDir := t.TempDir()
+	bareDir := filepath.Join(repoDir, ".bare")
+	require.NoError(t, os.Mkdir(bareDir, 0755))
+
+	oldCwd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(repoDir))
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	client := NewClient(Options{})
+
+	results := []DiscoverResult{
+		{Path: ".env", Strategy: StrategyCopy, Reason: "test"},
+		{Path: "node_modules", Strategy: StrategySymlink, Reason: "test"},
+	}
+
+	report, err := client.AddDiscoveredResources(results)
+	require.NoError(t, err)
+	assert.Len(t, report.Events, 2)
+
+	cfg, _, err := client.LoadSharedConfig()
+	require.NoError(t, err)
+	assert.Len(t, cfg.Resources, 2)
+	assert.Equal(t, ".env", cfg.Resources[0].Path)
+	assert.Equal(t, StrategyCopy, cfg.Resources[0].Strategy)
+	assert.Equal(t, "node_modules", cfg.Resources[1].Path)
+	assert.Equal(t, StrategySymlink, cfg.Resources[1].Strategy)
+}


### PR DESCRIPTION
### What's changed?

- Add `gmc wt share discover` subcommand that scans the main worktree for files that should be shared across worktrees
- Built-in candidate lists for copy (`.env*`, `.claude/*`, `.serena/*`) and link (`node_modules`, `.venv`, `vendor`, `__pycache__`) strategies
- Auto-detect main/master worktree, skip already-configured paths
- `--auto` flag to batch-add discovered resources and sync in one shot
- `--dry-run` flag (default) for preview mode
- `AddDiscoveredResources` batch method — single config load/save cycle
- 6 unit tests covering discovery, skip-existing, empty, all-candidates, and batch-add

### Why

- Replaces the shell script `skills/gmc/scripts/wt-share-discover.sh` with native Go
- Provides a first-class CLI experience for discovering shareable files
- Closes #54