### PR TITLE
[Fix] Configure bare linked worktrees

### DIFF
--- a/internal/worktree/pr.go
+++ b/internal/worktree/pr.go
@@ -112,6 +112,9 @@ func (c *Client) AddPR(prNumber int, remote string) (Report, error) {
 	if err != nil {
 		return report, gitutil.WrapGitError("failed to create worktree", result, err)
 	}
+	if err := c.ensureAddedWorktreeConfig(targetPath); err != nil {
+		return report, err
+	}
 
 	sharedReport, err := c.syncSharedResourcesToPath(targetPath, true)
 	report.Merge(sharedReport)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -597,7 +597,7 @@ func (c *Client) addArgs(ctx addContext) ([]string, bool) {
 }
 
 func (c *Client) ensureAddedWorktreeConfig(targetPath string) error {
-	if c.getGitOutput(c.repoDir, "config", "--bool", "extensions.worktreeConfig") != "true" {
+	if c.getGitOutput(c.repoDir, "config", "--local", "--bool", "extensions.worktreeConfig") != "true" {
 		return nil
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -370,6 +370,9 @@ func (c *Client) Add(name string, opts AddOptions) (Report, error) {
 	if err != nil {
 		return report, gitutil.WrapGitError("failed to create worktree", result, err)
 	}
+	if err := c.ensureAddedWorktreeConfig(ctx.targetPath); err != nil {
+		return report, err
+	}
 
 	sharedReport, err := c.syncSharedResourcesToPath(ctx.targetPath, true)
 	report.Merge(sharedReport)
@@ -593,6 +596,18 @@ func (c *Client) addArgs(ctx addContext) ([]string, bool) {
 	return []string{"-C", ctx.repoDir, "worktree", "add", "-b", ctx.name, ctx.targetPath, ctx.baseBranch}, false
 }
 
+func (c *Client) ensureAddedWorktreeConfig(targetPath string) error {
+	if c.getGitOutput(c.repoDir, "config", "--bool", "extensions.worktreeConfig") != "true" {
+		return nil
+	}
+
+	result, err := c.runner.RunLogged("-C", targetPath, "config", "--worktree", "core.bare", "false")
+	if err != nil {
+		return gitutil.WrapGitError("failed to configure worktree", result, err)
+	}
+	return nil
+}
+
 func (c *Client) appendAddSummary(report *Report, ctx addContext, branchExists bool) {
 	report.Info(fmt.Sprintf("Created worktree '%s' at %s", ctx.name, ctx.targetPath))
 	if branchExists {
@@ -767,6 +782,9 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 		runResult, err := c.runner.RunLogged(args...)
 		if err != nil {
 			return nil, gitutil.WrapGitError("failed to create worktree "+dirName, runResult, err)
+		}
+		if err := c.ensureAddedWorktreeConfig(targetPath); err != nil {
+			return nil, err
 		}
 
 		sharedReport, err := c.syncSharedResourcesToPath(targetPath, true)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -871,6 +871,35 @@ func TestAddDoesNotRequireWorktreeConfig(t *testing.T) {
 	}
 }
 
+func TestAddIgnoresGlobalWorktreeConfig(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+
+	globalConfig := filepath.Join(t.TempDir(), "global.gitconfig")
+	writeFile(t, globalConfig, "[extensions]\n\tworktreeConfig = true\n")
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient(Options{})
+	if _, err := client.Add("feature-global-config", AddOptions{BaseBranch: "main"}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	featureDir := filepath.Join(repoDir, "feature-global-config")
+	status := runGit(t, featureDir, "status", "--short", "--branch")
+	if !strings.Contains(status, "## feature-global-config") {
+		t.Fatalf("new worktree status = %q, want feature-global-config branch", status)
+	}
+}
+
 func TestDupConfiguresBareLayoutWorktreeConfig(t *testing.T) {
 	repoDir := initBareLayoutRepoWithWorktreeConfig(t)
 	mainDir := filepath.Join(repoDir, "main")

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -748,6 +748,26 @@ func initBareLayoutRepo(t *testing.T) string {
 	return tmpDir
 }
 
+func initBareLayoutRepoWithWorktreeConfig(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	bareDir := filepath.Join(tmpDir, ".bare")
+	runGit(t, tmpDir, "init", "--bare", bareDir)
+	runGit(t, bareDir, "config", "extensions.worktreeConfig", "true")
+	runGit(t, bareDir, "config", "user.name", "Test User")
+	runGit(t, bareDir, "config", "user.email", "test@example.com")
+
+	mainDir := filepath.Join(tmpDir, "main")
+	runGit(t, bareDir, "worktree", "add", mainDir, "-b", "main")
+	runGit(t, mainDir, "config", "--worktree", "core.bare", "false")
+	writeFile(t, filepath.Join(mainDir, "README.md"), "init")
+	runGit(t, mainDir, "add", ".")
+	runGit(t, mainDir, "commit", "-m", "init")
+
+	return tmpDir
+}
+
 func TestClientCacheInitialization(t *testing.T) {
 	repoDir := initBareLayoutRepo(t)
 	repoDir, _ = filepath.EvalSymlinks(repoDir)
@@ -793,6 +813,95 @@ func TestClientCacheInitialization(t *testing.T) {
 	root2, _ := client.GetWorktreeRoot()
 	if root2 != root {
 		t.Errorf("second GetWorktreeRoot() = %q, want %q (should be cached)", root2, root)
+	}
+}
+
+func TestAddConfiguresBareLayoutWorktreeConfig(t *testing.T) {
+	repoDir := initBareLayoutRepoWithWorktreeConfig(t)
+	mainDir := filepath.Join(repoDir, "main")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient(Options{})
+	if _, err := client.Add("feature-config", AddOptions{BaseBranch: "main"}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	featureDir := filepath.Join(repoDir, "feature-config")
+	status := runGit(t, featureDir, "status", "--short", "--branch")
+	if !strings.Contains(status, "## feature-config") {
+		t.Fatalf("new worktree status = %q, want feature-config branch", status)
+	}
+
+	got := strings.TrimSpace(runGit(t, featureDir, "config", "--worktree", "--bool", "core.bare"))
+	if got != "false" {
+		t.Fatalf("worktree core.bare = %q, want false", got)
+	}
+}
+
+func TestAddDoesNotRequireWorktreeConfig(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient(Options{})
+	if _, err := client.Add("feature-no-config", AddOptions{BaseBranch: "main"}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	featureDir := filepath.Join(repoDir, "feature-no-config")
+	status := runGit(t, featureDir, "status", "--short", "--branch")
+	if !strings.Contains(status, "## feature-no-config") {
+		t.Fatalf("new worktree status = %q, want feature-no-config branch", status)
+	}
+}
+
+func TestDupConfiguresBareLayoutWorktreeConfig(t *testing.T) {
+	repoDir := initBareLayoutRepoWithWorktreeConfig(t)
+	mainDir := filepath.Join(repoDir, "main")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient(Options{})
+	result, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1})
+	if err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+	if len(result.Worktrees) != 1 {
+		t.Fatalf("Dup() worktrees = %d, want 1", len(result.Worktrees))
+	}
+
+	dupDir := filepath.Join(repoDir, result.Worktrees[0])
+	status := runGit(t, dupDir, "status", "--short", "--branch")
+	if !strings.Contains(status, "## "+result.Branches[0]) {
+		t.Fatalf("new worktree status = %q, want %s branch", status, result.Branches[0])
+	}
+
+	got := strings.TrimSpace(runGit(t, dupDir, "config", "--worktree", "--bool", "core.bare"))
+	if got != "false" {
+		t.Fatalf("worktree core.bare = %q, want false", got)
 	}
 }
 


### PR DESCRIPTION
### What's changed?

- Set `core.bare=false` in newly created linked worktrees when `extensions.worktreeConfig` is enabled.
- Apply the same worktree-local config fix to `wt add`, `wt dup`, and PR worktree creation.
- Add regression coverage for `.bare + extensions.worktreeConfig` and for bare layouts without worktree config.

### Why

- Fixes linked worktrees inheriting `core.bare=true` from `.bare/config`, which made normal Git commands fail with `fatal: this operation must be run in a work tree`.

Fixes #66