### PR TITLE
[Feat] Show review request status for worktrees

### DIFF
--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/samzong/gmc/internal/worktree"
@@ -167,6 +168,81 @@ func TestRunWorktreeList_TextUnchanged(t *testing.T) {
 	assert.Contains(t, output, "BRANCH")
 	assert.Contains(t, output, "feature/text-check")
 	assert.NotContains(t, output, `"name"`)
+}
+
+func TestBuildWorktreeJSON_WithReviewStates(t *testing.T) {
+	repoDir := initCmdTestRepo(t)
+	oldCwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldCwd) }()
+	require.NoError(t, os.Chdir(repoDir))
+
+	client := worktree.NewClient(worktree.Options{})
+	items := buildWorktreeJSON(client, []worktree.Info{{
+		Path:   repoDir,
+		Branch: "feature/pr-json",
+		Commit: strings.Repeat("a", 40),
+	}}, map[string]worktree.ReviewInfo{
+		"feature/pr-json": {
+			Provider:   "github",
+			Number:     42,
+			State:      "OPEN",
+			HeadBranch: "feature/pr-json",
+			URL:        "https://github.com/example/repo/pull/42",
+		},
+	})
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "github", items[0].ReviewProvider)
+	assert.Equal(t, 42, items[0].ReviewNumber)
+	assert.Equal(t, "OPEN", items[0].ReviewState)
+	assert.Equal(t, "https://github.com/example/repo/pull/42", items[0].ReviewURL)
+}
+
+func TestPrintWorktreeTable_WithReviewStates(t *testing.T) {
+	repoDir := initCmdTestRepo(t)
+	oldCwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldCwd) }()
+	require.NoError(t, os.Chdir(repoDir))
+
+	var out bytes.Buffer
+	withWriters(t, &out, io.Discard)
+
+	client := worktree.NewClient(worktree.Options{})
+	printWorktreeTable(client, []worktree.Info{{
+		Path:   repoDir,
+		Branch: "feature/pr-text",
+		Commit: strings.Repeat("b", 40),
+	}}, map[string]worktree.ReviewInfo{
+		"feature/pr-text": {
+			Provider:   "github",
+			Number:     42,
+			State:      "OPEN",
+			HeadBranch: "feature/pr-text",
+			URL:        "https://github.com/example/repo/pull/42",
+		},
+	})
+
+	output := out.String()
+	assert.Contains(t, output, "PR")
+	assert.Contains(t, output, "#42 OPEN")
+	assert.NotContains(t, output, "https://github.com/example/repo/pull/42")
+}
+
+func TestFormatWorktreeReviewDisplay_LinksNumber(t *testing.T) {
+	text := formatWorktreeReviewDisplay(map[string]worktree.ReviewInfo{
+		"feature/pr-link": {
+			Provider:   "gitlab",
+			Number:     42,
+			State:      "OPEN",
+			HeadBranch: "feature/pr-link",
+			URL:        "https://gitlab.com/example/repo/-/merge_requests/42",
+		},
+	}, "feature/pr-link", true)
+
+	assert.Contains(t, text, "\x1b]8;;https://gitlab.com/example/repo/-/merge_requests/42\x1b\\#42\x1b]8;;\x1b\\")
+	assert.Contains(t, text, " OPEN")
 }
 
 func TestResolveWorktreeStatus(t *testing.T) {

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/mattn/go-isatty"
 	"github.com/samzong/gmc/internal/stringsutil"
 	"github.com/samzong/gmc/internal/worktree"
 	"github.com/spf13/cobra"
@@ -23,6 +25,7 @@ var (
 	wtUpstream     string
 	wtProjectName  string
 	prRemote       string
+	wtShowPR       bool
 )
 
 var wtCmd = &cobra.Command{
@@ -260,6 +263,10 @@ func init() {
 	// Flags for pr-review command
 	wtPrReviewCmd.Flags().StringVarP(&prRemote, "remote", "r", "",
 		"Remote to fetch PR from (auto-detect if not specified)")
+	wtCmd.Flags().BoolVar(&wtShowPR, "pr", false,
+		"Show review request status for each branch (requires gh or glab CLI)")
+	wtListCmd.Flags().BoolVar(&wtShowPR, "pr", false,
+		"Show review request status for each branch (requires gh or glab CLI)")
 
 	// Shell completions for arguments
 	wtRemoveCmd.ValidArgsFunction = completeWorktreeNames
@@ -276,11 +283,15 @@ func init() {
 }
 
 type WorktreeJSON struct {
-	Name   string `json:"name"`
-	Path   string `json:"path"`
-	Branch string `json:"branch"`
-	Commit string `json:"commit"`
-	Status string `json:"status"`
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	Branch         string `json:"branch"`
+	Commit         string `json:"commit"`
+	Status         string `json:"status"`
+	ReviewProvider string `json:"review_provider,omitempty"`
+	ReviewNumber   int    `json:"review_number,omitempty"`
+	ReviewState    string `json:"review_state,omitempty"`
+	ReviewURL      string `json:"review_url,omitempty"`
 }
 
 func runWorktreeDefault(wtClient *worktree.Client, _ *cobra.Command) error {
@@ -290,13 +301,18 @@ func runWorktreeDefault(wtClient *worktree.Client, _ *cobra.Command) error {
 	}
 
 	filtered := filterBareWorktrees(worktrees)
+	reviews := loadWorktreeReviews(wtClient, filtered)
 
 	if outputFormat() == "json" {
-		return printWorktreeJSON(wtClient, filtered)
+		if err := printWorktreeJSON(wtClient, filtered, reviews.Reviews); err != nil {
+			return err
+		}
+		printReviewWarning(errWriter(), reviews)
+		return nil
 	}
 
 	fmt.Fprintln(outWriter(), "Current Worktrees:")
-	printWorktreeTable(wtClient, filtered)
+	printWorktreeTable(wtClient, filtered, reviews.Reviews)
 
 	cwd, err := os.Getwd()
 	if err == nil {
@@ -308,6 +324,7 @@ func runWorktreeDefault(wtClient *worktree.Client, _ *cobra.Command) error {
 			}
 		}
 	}
+	printReviewWarning(outWriter(), reviews)
 
 	return nil
 }
@@ -371,9 +388,14 @@ func runWorktreeList(wtClient *worktree.Client) error {
 	}
 
 	filtered := filterBareWorktrees(worktrees)
+	reviews := loadWorktreeReviews(wtClient, filtered)
 
 	if outputFormat() == "json" {
-		return printWorktreeJSON(wtClient, filtered)
+		if err := printWorktreeJSON(wtClient, filtered, reviews.Reviews); err != nil {
+			return err
+		}
+		printReviewWarning(errWriter(), reviews)
+		return nil
 	}
 
 	if len(filtered) == 0 {
@@ -381,7 +403,8 @@ func runWorktreeList(wtClient *worktree.Client) error {
 		return nil
 	}
 
-	printWorktreeTable(wtClient, filtered)
+	printWorktreeTable(wtClient, filtered, reviews.Reviews)
+	printReviewWarning(outWriter(), reviews)
 	return nil
 }
 
@@ -527,15 +550,75 @@ func resolveWorktreeStatus(wtClient *worktree.Client, root string, wt worktree.I
 	}
 }
 
-func printWorktreeTable(wtClient *worktree.Client, worktrees []worktree.Info) {
+func loadWorktreeReviews(wtClient *worktree.Client, worktrees []worktree.Info) worktree.ReviewLookup {
+	if !wtShowPR || len(worktrees) == 0 {
+		return worktree.ReviewLookup{}
+	}
+	return wtClient.ReviewStates()
+}
+
+func printReviewWarning(w io.Writer, reviews worktree.ReviewLookup) {
+	if reviews.Warning == "" {
+		return
+	}
+	fmt.Fprintln(w, "Warning: "+reviews.Warning)
+}
+
+func formatWorktreeReview(reviews map[string]worktree.ReviewInfo, branch string) string {
+	if reviews == nil {
+		return ""
+	}
+	review, ok := reviews[branch]
+	if !ok {
+		return "-"
+	}
+	if review.State == "" {
+		return fmt.Sprintf("#%d", review.Number)
+	}
+	return fmt.Sprintf("#%d %s", review.Number, review.State)
+}
+
+func formatWorktreeReviewDisplay(reviews map[string]worktree.ReviewInfo, branch string, links bool) string {
+	text := formatWorktreeReview(reviews, branch)
+	if text == "" || text == "-" || !links {
+		return text
+	}
+	review, ok := reviews[branch]
+	if !ok || review.URL == "" || review.Number == 0 {
+		return text
+	}
+	number := fmt.Sprintf("#%d", review.Number)
+	linked := fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", review.URL, number)
+	return strings.Replace(text, number, linked, 1)
+}
+
+func terminalLinksEnabled(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return isatty.IsTerminal(file.Fd()) || isatty.IsCygwinTerminal(file.Fd())
+}
+
+func padVisibleRight(text string, visibleLen int, width int) string {
+	if visibleLen >= width {
+		return text
+	}
+	return text + strings.Repeat(" ", width-visibleLen)
+}
+
+func printWorktreeTable(wtClient *worktree.Client, worktrees []worktree.Info, reviews map[string]worktree.ReviewInfo) {
 	if len(worktrees) == 0 {
 		return
 	}
 
 	root := getDisplayRoot(wtClient)
+	writer := outWriter()
+	links := terminalLinksEnabled(writer)
 
 	maxName := len("Name")
 	maxBranch := len("Branch")
+	maxPR := len("PR")
 	for _, wt := range worktrees {
 		name := displayWorktreeName(root, wt.Path)
 		if len(name) > maxName {
@@ -544,38 +627,88 @@ func printWorktreeTable(wtClient *worktree.Client, worktrees []worktree.Info) {
 		if len(wt.Branch) > maxBranch {
 			maxBranch = len(wt.Branch)
 		}
+		prText := formatWorktreeReview(reviews, wt.Branch)
+		if len(prText) > maxPR {
+			maxPR = len(prText)
+		}
 	}
 
 	maxName += 2
 	maxBranch += 2
+	maxPR += 2
 
-	fmt.Fprintf(outWriter(), "%-*s %-*s %-8s %s\n", maxName, "NAME", maxBranch, "BRANCH", "COMMIT", "STATUS")
+	if reviews != nil {
+		fmt.Fprintf(
+			writer,
+			"%-*s %-*s %-8s %-*s %s\n",
+			maxName, "NAME",
+			maxBranch, "BRANCH",
+			"COMMIT",
+			maxPR, "PR",
+			"STATUS",
+		)
+	} else {
+		fmt.Fprintf(writer, "%-*s %-*s %-8s %s\n", maxName, "NAME", maxBranch, "BRANCH", "COMMIT", "STATUS")
+	}
 
 	for _, wt := range worktrees {
 		name := displayWorktreeName(root, wt.Path)
 		shortCommit := stringsutil.ShortHash(wt.Commit, 7, "")
 		status := resolveWorktreeStatus(wtClient, root, wt)
-		fmt.Fprintf(outWriter(), "%-*s %-*s %-8s %s\n", maxName, name, maxBranch, wt.Branch, shortCommit, status)
+		if reviews != nil {
+			prText := formatWorktreeReview(reviews, wt.Branch)
+			prDisplay := formatWorktreeReviewDisplay(reviews, wt.Branch, links)
+			fmt.Fprintf(
+				writer,
+				"%-*s %-*s %-8s %s %s\n",
+				maxName, name,
+				maxBranch, wt.Branch,
+				shortCommit,
+				padVisibleRight(prDisplay, len(prText), maxPR),
+				status,
+			)
+		} else {
+			fmt.Fprintf(writer, "%-*s %-*s %-8s %s\n", maxName, name, maxBranch, wt.Branch, shortCommit, status)
+		}
 	}
 }
 
-func buildWorktreeJSON(wtClient *worktree.Client, worktrees []worktree.Info) []WorktreeJSON {
+func buildWorktreeJSON(
+	wtClient *worktree.Client,
+	worktrees []worktree.Info,
+	reviews map[string]worktree.ReviewInfo,
+) []WorktreeJSON {
 	root := getDisplayRoot(wtClient)
 	result := make([]WorktreeJSON, 0, len(worktrees))
 	for _, wt := range worktrees {
-		result = append(result, WorktreeJSON{
+		item := WorktreeJSON{
 			Name:   displayWorktreeName(root, wt.Path),
 			Path:   wt.Path,
 			Branch: wt.Branch,
 			Commit: wt.Commit,
 			Status: resolveWorktreeStatus(wtClient, root, wt),
-		})
+		}
+		if reviews != nil {
+			if review, ok := reviews[wt.Branch]; ok {
+				item.ReviewProvider = review.Provider
+				item.ReviewNumber = review.Number
+				item.ReviewState = review.State
+				item.ReviewURL = review.URL
+			} else {
+				item.ReviewState = "none"
+			}
+		}
+		result = append(result, item)
 	}
 	return result
 }
 
-func printWorktreeJSON(wtClient *worktree.Client, worktrees []worktree.Info) error {
-	return printJSON(outWriter(), buildWorktreeJSON(wtClient, worktrees))
+func printWorktreeJSON(
+	wtClient *worktree.Client,
+	worktrees []worktree.Info,
+	reviews map[string]worktree.ReviewInfo,
+) error {
+	return printJSON(outWriter(), buildWorktreeJSON(wtClient, worktrees, reviews))
 }
 
 func runWorktreeDup(wtClient *worktree.Client, args []string) error {

--- a/internal/worktree/review.go
+++ b/internal/worktree/review.go
@@ -1,0 +1,310 @@
+package worktree
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	reviewProviderGitHub = "github"
+	reviewProviderGitLab = "gitlab"
+)
+
+type ReviewInfo struct {
+	Provider   string
+	Number     int
+	State      string
+	HeadBranch string
+	URL        string
+}
+
+type ReviewLookup struct {
+	Reviews map[string]ReviewInfo
+	Warning string
+}
+
+type reviewRemote struct {
+	name     string
+	url      string
+	provider string
+}
+
+type missingReviewToolError struct {
+	tool string
+}
+
+func (e missingReviewToolError) Error() string {
+	return e.tool + " CLI not found"
+}
+
+var reviewRunFunc = reviewRunDefault
+
+func reviewRunDefault(repoDir string, tool string, args ...string) ([]byte, error) {
+	if _, err := exec.LookPath(tool); err != nil {
+		return nil, missingReviewToolError{tool: tool}
+	}
+	cmd := exec.Command(tool, args...)
+	cmd.Dir = repoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return nil, fmt.Errorf("%s failed: %s", tool, msg)
+		}
+		return nil, fmt.Errorf("%s failed: %w", tool, err)
+	}
+	return out, nil
+}
+
+func (c *Client) ReviewStates() ReviewLookup {
+	result := ReviewLookup{Reviews: map[string]ReviewInfo{}}
+	if err := c.ensureInit(); err != nil {
+		result.Warning = "review lookup skipped: failed to initialize repository: " + err.Error()
+		return result
+	}
+
+	remote, err := c.detectReviewRemote()
+	if err != nil {
+		result.Warning = "review lookup skipped: " + err.Error()
+		return result
+	}
+
+	var reviews map[string]ReviewInfo
+	switch remote.provider {
+	case reviewProviderGitHub:
+		reviews, err = githubReviewStates(c.repoDir, remote.url)
+	case reviewProviderGitLab:
+		reviews, err = gitlabReviewStates(c.repoDir, remote.url)
+	default:
+		err = fmt.Errorf("unsupported review provider for remote %q", remote.name)
+	}
+	if err != nil {
+		result.Warning = reviewLookupWarning(remote.provider, err)
+		return result
+	}
+	result.Reviews = reviews
+	return result
+}
+
+func (c *Client) detectReviewRemote() (reviewRemote, error) {
+	remotes, err := c.ListRemotes()
+	if err != nil {
+		return reviewRemote{}, err
+	}
+	if len(remotes) == 0 {
+		return reviewRemote{}, errors.New("no git remotes found")
+	}
+
+	candidates := reviewRemoteCandidates(remotes)
+	var unsupported []string
+	for _, remote := range candidates {
+		remoteURL, err := c.remoteURL(remote)
+		if err != nil {
+			return reviewRemote{}, err
+		}
+		provider := reviewProviderFromRemoteURL(remoteURL)
+		if provider == "" {
+			unsupported = append(unsupported, remote)
+			continue
+		}
+		return reviewRemote{name: remote, url: remoteURL, provider: provider}, nil
+	}
+	if len(unsupported) > 0 {
+		return reviewRemote{}, fmt.Errorf("unsupported remote host for %s", strings.Join(unsupported, ", "))
+	}
+	return reviewRemote{}, errors.New("no usable git remote found")
+}
+
+func (c *Client) remoteURL(remote string) (string, error) {
+	result, err := c.runner.Run("-C", c.repoDir, "remote", "get-url", remote)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote URL for %s: %w", remote, err)
+	}
+	return result.StdoutString(true), nil
+}
+
+func reviewRemoteCandidates(remotes []string) []string {
+	var candidates []string
+	add := func(name string) {
+		for _, remote := range remotes {
+			if remote == name {
+				candidates = append(candidates, remote)
+				return
+			}
+		}
+	}
+	add("upstream")
+	add("origin")
+	if len(candidates) == 0 && len(remotes) == 1 {
+		candidates = append(candidates, remotes[0])
+	}
+	return candidates
+}
+
+func reviewProviderFromRemoteURL(remoteURL string) string {
+	host := strings.ToLower(remoteHost(remoteURL))
+	switch {
+	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
+		return reviewProviderGitHub
+	case strings.Contains(host, "gitlab"):
+		return reviewProviderGitLab
+	case os.Getenv("GITLAB_HOST") != "" && host == strings.ToLower(os.Getenv("GITLAB_HOST")):
+		return reviewProviderGitLab
+	default:
+		return ""
+	}
+}
+
+func remoteHost(remoteURL string) string {
+	trimmed := strings.TrimSpace(remoteURL)
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Host != "" {
+		return stripPort(parsed.Host)
+	}
+	if at := strings.Index(trimmed, "@"); at >= 0 {
+		rest := trimmed[at+1:]
+		if colon := strings.Index(rest, ":"); colon >= 0 {
+			return stripPort(rest[:colon])
+		}
+		if slash := strings.Index(rest, "/"); slash >= 0 {
+			return stripPort(rest[:slash])
+		}
+	}
+	return ""
+}
+
+func stripPort(host string) string {
+	if colon := strings.LastIndex(host, ":"); colon >= 0 {
+		return host[:colon]
+	}
+	return host
+}
+
+type githubReviewInfo struct {
+	Number      int    `json:"number"`
+	State       string `json:"state"`
+	HeadRefName string `json:"headRefName"`
+	URL         string `json:"url"`
+}
+
+func githubReviewStates(repoDir string, repoURL string) (map[string]ReviewInfo, error) {
+	out, err := reviewRunFunc(repoDir,
+		"gh",
+		"pr", "list",
+		"-R", repoURL,
+		"--state", "all",
+		"--json", "number,state,headRefName,url",
+		"--limit", "300",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []githubReviewInfo
+	if err := decodeReviewJSON(out, &prs); err != nil {
+		return nil, err
+	}
+
+	reviews := make(map[string]ReviewInfo, len(prs))
+	for _, pr := range prs {
+		if _, exists := reviews[pr.HeadRefName]; exists {
+			continue
+		}
+		reviews[pr.HeadRefName] = ReviewInfo{
+			Provider:   reviewProviderGitHub,
+			Number:     pr.Number,
+			State:      normalizeReviewState(pr.State),
+			HeadBranch: pr.HeadRefName,
+			URL:        pr.URL,
+		}
+	}
+	return reviews, nil
+}
+
+type gitlabReviewInfo struct {
+	IID          int    `json:"iid"`
+	State        string `json:"state"`
+	SourceBranch string `json:"source_branch"`
+	WebURL       string `json:"web_url"`
+}
+
+func gitlabReviewStates(repoDir string, repoURL string) (map[string]ReviewInfo, error) {
+	out, err := reviewRunFunc(repoDir,
+		"glab",
+		"mr", "list",
+		"-R", repoURL,
+		"--all",
+		"--output", "json",
+		"--per-page", "100",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var mrs []gitlabReviewInfo
+	if err := decodeReviewJSON(out, &mrs); err != nil {
+		return nil, err
+	}
+
+	reviews := make(map[string]ReviewInfo, len(mrs))
+	for _, mr := range mrs {
+		if _, exists := reviews[mr.SourceBranch]; exists {
+			continue
+		}
+		reviews[mr.SourceBranch] = ReviewInfo{
+			Provider:   reviewProviderGitLab,
+			Number:     mr.IID,
+			State:      normalizeReviewState(mr.State),
+			HeadBranch: mr.SourceBranch,
+			URL:        mr.WebURL,
+		}
+	}
+	return reviews, nil
+}
+
+func decodeReviewJSON(out []byte, target any) error {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" || trimmed == "[]" {
+		return nil
+	}
+	if err := json.Unmarshal([]byte(trimmed), target); err != nil {
+		return fmt.Errorf("failed to parse review lookup output: %w", err)
+	}
+	return nil
+}
+
+func normalizeReviewState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open", "opened":
+		return "OPEN"
+	case "merged":
+		return "MERGED"
+	case "closed", "closed_unmerged":
+		return "CLOSED"
+	default:
+		return strings.ToUpper(strings.TrimSpace(state))
+	}
+}
+
+func reviewLookupWarning(provider string, err error) string {
+	tool := "review"
+	name := "review"
+	switch provider {
+	case reviewProviderGitHub:
+		tool = "gh"
+		name = "GitHub PR"
+	case reviewProviderGitLab:
+		tool = "glab"
+		name = "GitLab MR"
+	}
+
+	var missing missingReviewToolError
+	if errors.As(err, &missing) {
+		return fmt.Sprintf("%s lookup skipped: %s CLI not found", name, tool)
+	}
+	return fmt.Sprintf("%s lookup skipped: %s failed; check authentication", name, tool)
+}

--- a/internal/worktree/review_test.go
+++ b/internal/worktree/review_test.go
@@ -1,0 +1,155 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReviewProviderFromRemoteURL(t *testing.T) {
+	t.Setenv("GITLAB_HOST", "gitlab.internal.example")
+
+	tests := []struct {
+		name      string
+		remoteURL string
+		want      string
+	}{
+		{"github https", "https://github.com/org/repo.git", reviewProviderGitHub},
+		{"github ssh", "git@github.com:org/repo.git", reviewProviderGitHub},
+		{"gitlab https", "https://gitlab.com/group/repo.git", reviewProviderGitLab},
+		{"gitlab host env", "git@gitlab.internal.example:group/repo.git", reviewProviderGitLab},
+		{"unsupported", "https://example.com/org/repo.git", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewProviderFromRemoteURL(tt.remoteURL); got != tt.want {
+				t.Fatalf("reviewProviderFromRemoteURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReviewStates_GitHub(t *testing.T) {
+	runReviewLookupTest(t, "https://github.com/org/repo.git", "gh", `[
+		{
+			"number": 42,
+			"state": "OPEN",
+			"headRefName": "feature/github",
+			"url": "https://github.com/org/repo/pull/42"
+		}
+	]`)
+
+	result := NewClient(Options{}).ReviewStates()
+	if result.Warning != "" {
+		t.Fatalf("Warning = %q, want empty", result.Warning)
+	}
+	review := result.Reviews["feature/github"]
+	if review.Provider != reviewProviderGitHub || review.Number != 42 || review.State != "OPEN" {
+		t.Fatalf("unexpected review: %+v", review)
+	}
+}
+
+func TestReviewStates_GitLab(t *testing.T) {
+	runReviewLookupTest(t, "https://gitlab.com/group/repo.git", "glab", `[
+		{
+			"iid": 7,
+			"state": "opened",
+			"source_branch": "feature/gitlab",
+			"web_url": "https://gitlab.com/group/repo/-/merge_requests/7"
+		}
+	]`)
+
+	result := NewClient(Options{}).ReviewStates()
+	if result.Warning != "" {
+		t.Fatalf("Warning = %q, want empty", result.Warning)
+	}
+	review := result.Reviews["feature/gitlab"]
+	if review.Provider != reviewProviderGitLab || review.Number != 7 || review.State != "OPEN" {
+		t.Fatalf("unexpected review: %+v", review)
+	}
+}
+
+func TestReviewStates_WarnsOnMissingCLI(t *testing.T) {
+	runReviewLookupFailureTest(t, func(repoDir string, tool string, args ...string) ([]byte, error) {
+		return nil, missingReviewToolError{tool: tool}
+	})
+
+	result := NewClient(Options{}).ReviewStates()
+	if !strings.Contains(result.Warning, "gh CLI not found") {
+		t.Fatalf("Warning = %q, want missing gh warning", result.Warning)
+	}
+	if result.Reviews == nil || len(result.Reviews) != 0 {
+		t.Fatalf("Reviews = %+v, want empty non-nil map", result.Reviews)
+	}
+}
+
+func TestReviewStates_WarnsOnAuthFailure(t *testing.T) {
+	runReviewLookupFailureTest(t, func(repoDir string, tool string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("%s failed: authentication required", tool)
+	})
+
+	result := NewClient(Options{}).ReviewStates()
+	if !strings.Contains(result.Warning, "check authentication") {
+		t.Fatalf("Warning = %q, want authentication warning", result.Warning)
+	}
+}
+
+func runReviewLookupTest(t *testing.T, remoteURL string, wantTool string, output string) {
+	t.Helper()
+	repoDir := initTestRepo(t)
+	runGit(t, repoDir, "remote", "add", "origin", remoteURL)
+
+	oldRun := reviewRunFunc
+	t.Cleanup(func() { reviewRunFunc = oldRun })
+	reviewRunFunc = func(repoDir string, tool string, args ...string) ([]byte, error) {
+		if tool != wantTool {
+			t.Fatalf("tool = %q, want %s", tool, wantTool)
+		}
+		if !hasReviewArg(args, "-R", remoteURL) {
+			t.Fatalf("args = %v, want -R %s", args, remoteURL)
+		}
+		return []byte(output), nil
+	}
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasReviewArg(args []string, flag string, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func runReviewLookupFailureTest(
+	t *testing.T,
+	run func(repoDir string, tool string, args ...string) ([]byte, error),
+) {
+	t.Helper()
+	repoDir := initTestRepo(t)
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/org/repo.git")
+
+	oldRun := reviewRunFunc
+	t.Cleanup(func() { reviewRunFunc = oldRun })
+	reviewRunFunc = run
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
### What's changed?

- Add `gmc wt --pr` and `gmc wt list --pr` to show review request status for each worktree branch.
- Detect GitHub/GitLab remotes and query `gh`/`glab` with the selected remote URL.
- Render review numbers as clickable `#<number>` links in supported terminals and expose review metadata in JSON output.

### Verification

- `go test ./...`
- `git diff HEAD~1..HEAD --check`
- `go run . wt --pr`

Note: `make check` still has pre-existing lint failures and is intentionally handled in a separate PR.