### PR TITLE
[Fix] Pass make check lint

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 )
@@ -32,7 +32,7 @@ type outputFormatFlag struct {
 func (f *outputFormatFlag) String() string { return f.value }
 func (f *outputFormatFlag) Set(s string) error {
 	if s != "text" && s != "json" {
-		return fmt.Errorf("must be text or json")
+		return errors.New("must be text or json")
 	}
 	f.value = s
 	return nil

--- a/cmd/worktree_hook.go
+++ b/cmd/worktree_hook.go
@@ -17,7 +17,8 @@ var wtHookCmd = &cobra.Command{
 Hooks run in the target worktree directory and are useful for running
 package installation commands like 'pnpm install'.
 
-Config file is stored at the repository's shared git common dir (for example .git/gmc-share.yml or .bare/gmc-share.yml).`,
+Config file is stored at the repository's shared git common dir
+(for example .git/gmc-share.yml or .bare/gmc-share.yml).`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		wtClient := newWorktreeClient()
 		return runHookList(wtClient)

--- a/cmd/worktree_prune.go
+++ b/cmd/worktree_prune.go
@@ -79,7 +79,7 @@ func runWorktreePrune(wtClient *worktree.Client) error {
 
 func printPruneTable(entries []worktree.PruneEntry) {
 	w := tabwriter.NewWriter(outWriter(), 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tBRANCH\tPR\tPR STATE\tACTION\tREASON")
+	fmt.Fprintln(w, "NAME\tBRANCH\tPR\tSTATE\tACTION\tREASON")
 	for _, e := range entries {
 		pr := "-"
 		if e.PRNum > 0 {

--- a/cmd/worktree_share.go
+++ b/cmd/worktree_share.go
@@ -23,7 +23,8 @@ var wtShareCmd = &cobra.Command{
 
 If run without arguments, it opens an interactive mode to manage resources.
 
-Config file is stored at the repository's shared git common dir (for example .git/gmc-share.yml or .bare/gmc-share.yml).`,
+Config file is stored at the repository's shared git common dir
+(for example .git/gmc-share.yml or .bare/gmc-share.yml).`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		wtClient := newWorktreeClient()
 		return runWorktreeShareInteractive(wtClient)

--- a/cmd/worktree_switch.go
+++ b/cmd/worktree_switch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/charmbracelet/huh"
@@ -32,7 +33,7 @@ func runWorktreeSwitch(wtClient *worktree.Client) error {
 
 	filtered := filterBareWorktrees(worktrees)
 	if len(filtered) == 0 {
-		return fmt.Errorf("no worktrees found")
+		return errors.New("no worktrees found")
 	}
 
 	root := getDisplayRoot(wtClient)

--- a/internal/worktree/prune_test.go
+++ b/internal/worktree/prune_test.go
@@ -2,7 +2,7 @@ package worktree
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -173,7 +173,7 @@ func TestPrunePRAware_GhFailure(t *testing.T) {
 	orig := ghRunFunc
 	defer func() { ghRunFunc = orig }()
 	ghRunFunc = func(dir string, args ...string) ([]byte, error) {
-		return nil, fmt.Errorf("auth required")
+		return nil, errors.New("auth required")
 	}
 
 	cwd, _ := os.Getwd()

--- a/internal/worktree/resource_nonbare_test.go
+++ b/internal/worktree/resource_nonbare_test.go
@@ -37,7 +37,8 @@ func TestSyncAllSharedResources_WorksFromNonBareWorktreeRepo(t *testing.T) {
 	runGit(t, repoDir, "worktree", "add", "-b", "feature/test-sync-share", linkedWt, "main")
 
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".env"), []byte("SECRET=123"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), []byte("shared:\n  - path: .env\n    strategy: copy\n"), 0o644))
+	config := []byte("shared:\n  - path: .env\n    strategy: copy\n")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), config, 0o644))
 
 	client := NewClient(Options{})
 	oldCwd, err := os.Getwd()
@@ -59,7 +60,8 @@ func TestSyncAllSharedResources_DoesNotRunHooks(t *testing.T) {
 	runGit(t, repoDir, "worktree", "add", "-b", "feature/test-sync-hooks", linkedWt, "main")
 
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".env"), []byte("SECRET=123"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), []byte("shared:\n  - path: .env\n    strategy: copy\nhooks:\n  - cmd: printf 'hook-ran' > hook.txt\n"), 0o644))
+	config := []byte("shared:\n  - path: .env\n    strategy: copy\nhooks:\n  - cmd: printf 'hook-ran' > hook.txt\n")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), config, 0o644))
 
 	client := NewClient(Options{})
 	oldCwd, err := os.Getwd()
@@ -80,7 +82,8 @@ func TestSyncAllSharedResources_DoesNotRunHooks(t *testing.T) {
 
 func TestLoadSharedConfig_FallsBackToLegacyRepoRootConfig(t *testing.T) {
 	repoDir := initTestRepo(t)
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, legacySharedConfigYML), []byte("shared:\n  - path: .env\n    strategy: copy\n"), 0o644))
+	config := []byte("shared:\n  - path: .env\n    strategy: copy\n")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, legacySharedConfigYML), config, 0o644))
 
 	client := NewClient(Options{})
 	oldCwd, err := os.Getwd()
@@ -118,7 +121,8 @@ func TestRemoveSharedResource_NormalizesPath(t *testing.T) {
 	defer func() { _ = os.Chdir(oldCwd) }()
 	require.NoError(t, os.Chdir(repoDir))
 
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), []byte("shared:\n  - path: config/.env\n    strategy: copy\n"), 0o644))
+	config := []byte("shared:\n  - path: config/.env\n    strategy: copy\n")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "gmc-share.yml"), config, 0o644))
 
 	_, err = client.RemoveSharedResource("config/../config/.env")
 	require.NoError(t, err)

--- a/internal/worktree/share_discover.go
+++ b/internal/worktree/share_discover.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -140,5 +141,5 @@ func (c *Client) findMainWorktreePath() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("no worktree found to scan")
+	return "", errors.New("no worktree found to scan")
 }


### PR DESCRIPTION
### What's changed?

- Replace constant `fmt.Errorf` calls with `errors.New` where required by lint.
- Wrap long help and test setup lines to satisfy the line-length check.
- Rename the prune table header from `PR STATE` to `STATE` to avoid duplicate wording.

### Why

- Make the repository's canonical `make check` gate pass cleanly.

### Verification

- `make check`
- `git diff HEAD~1..HEAD --check`