### PR TITLE
[Feat] Promote candidates into parent worktree

### DIFF
--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -18,6 +18,7 @@ import (
 var (
 	wtBaseBranch   string
 	wtDupBase      string
+	wtDupTasks     []string
 	wtForce        bool
 	wtDeleteBranch bool
 	wtDryRun       bool
@@ -158,11 +159,18 @@ var wtDupCmd = &cobra.Command{
 
 Each worktree gets a temporary branch (_dup/<base>/<timestamp>-<n>). Point a
 different agent (Claude Code, Codex, Copilot, ...) at each one, compare the
-results, then promote the winner with 'gmc wt promote'.
+results, then promote the winner back into the current parent worktree with
+'gmc wt promote'.
+
+Use --task to copy task context files from the parent worktree into each
+candidate. Task files are ordinary files after they are copied.
 
 Examples:
   # Fan out 3 sibling worktrees based on main
   gmc wt dup 3 -b main
+
+  # Fan out candidates with a copied task file
+  gmc wt dup 3 --task todo.md
 
   # Typical parallel workflow with Claude Code / Codex / Copilot
   gmc wt dup 3
@@ -170,8 +178,8 @@ Examples:
   cd ../.dup-2 && codex     # agent 2
   cd ../.dup-3 && copilot   # agent 3
 
-  # When one agent's solution wins, promote it to a real branch:
-  gmc wt promote .dup-1 feature/auth
+  # When one agent's solution wins, promote it into the current worktree:
+  gmc wt promote .dup-1
 
   # Defaults: count=2, base=main
   gmc wt dup
@@ -184,19 +192,33 @@ Examples:
 }
 
 var wtPromoteCmd = &cobra.Command{
-	Use:   "promote <worktree> <branch-name>",
-	Short: "Rename temporary branch to permanent name",
-	Long: `Rename the temporary branch of a worktree to a permanent branch name.
+	Use:   "promote <candidate>",
+	Short: "Apply a candidate back into the current worktree",
+	Long: `Apply a candidate worktree's changes back into the current parent worktree.
 
-Use this after evaluating parallel development results to keep the best solution.
+Run this from the parent worktree that should receive the winning candidate.
+The result is left as uncommitted working tree changes. This command never
+commits, pushes, opens PRs, or deletes candidate worktrees.
 
 Examples:
-  gmc wt promote .dup-2 feature/add-auth
-  gmc wt promote .dup-1 fix/login-bug`,
-	Args: cobra.ExactArgs(2),
+  gmc wt promote .dup-2 --dry-run
+  gmc wt promote .dup-2
+  gmc wt promote ../.dup-1`,
+	Args: func(_ *cobra.Command, args []string) error {
+		if len(args) == 2 {
+			return errors.New(
+				"gmc wt promote now accepts only <candidate>; " +
+					"to rename a branch, cd into the worktree and run 'git branch -m <branch-name>'",
+			)
+		}
+		if len(args) != 1 {
+			return errors.New("requires exactly 1 arg(s)")
+		}
+		return nil
+	},
 	RunE: func(_ *cobra.Command, args []string) error {
 		wtClient := newWorktreeClient()
-		return runWorktreePromote(wtClient, args[0], args[1])
+		return runWorktreePromote(wtClient, args[0])
 	},
 }
 
@@ -252,6 +274,10 @@ func init() {
 
 	// Flags for dup command
 	wtDupCmd.Flags().StringVarP(&wtDupBase, "base", "b", "main", "Base branch to create from")
+	wtDupCmd.Flags().StringArrayVar(&wtDupTasks, "task", nil, "Task context file to copy into each candidate (repeatable)")
+
+	wtPromoteCmd.Flags().BoolVar(&wtDryRun, "dry-run", false,
+		"Check whether the candidate can be promoted without changing files")
 
 	// Flags for prune command
 	wtPruneCmd.Flags().StringVarP(&wtPruneBase, "base", "b", "", "Base branch to check merge status against")
@@ -715,6 +741,7 @@ func runWorktreeDup(wtClient *worktree.Client, args []string) error {
 	opts := worktree.DupOptions{
 		BaseBranch: wtDupBase,
 		Count:      2,
+		TaskFiles:  wtDupTasks,
 	}
 
 	if len(args) > 0 {
@@ -735,20 +762,41 @@ func runWorktreeDup(wtClient *worktree.Client, args []string) error {
 
 	fmt.Fprintf(outWriter(), "Created %d worktrees based on '%s':\n", len(result.Worktrees), opts.BaseBranch)
 	for i, wt := range result.Worktrees {
-		fmt.Fprintf(outWriter(), "  %s -> %s\n", wt, result.Branches[i])
+		relPath := wt
+		if i < len(result.RelativePaths) && result.RelativePaths[i] != "" {
+			relPath = result.RelativePaths[i]
+		}
+		absPath := ""
+		if i < len(result.WorktreePaths) {
+			absPath = result.WorktreePaths[i]
+		}
+		if absPath == "" {
+			fmt.Fprintf(outWriter(), "  %s -> %s\n", relPath, result.Branches[i])
+		} else {
+			fmt.Fprintf(outWriter(), "  %s (%s) -> %s\n", relPath, absPath, result.Branches[i])
+		}
+	}
+	if len(result.TaskFiles) > 0 {
+		fmt.Fprintln(outWriter(), "Copied task files:")
+		for _, task := range result.TaskFiles {
+			fmt.Fprintf(outWriter(), "  %s\n", task)
+		}
 	}
 	fmt.Fprintln(outWriter())
 	fmt.Fprintln(outWriter(), "Next steps:")
 	fmt.Fprintln(outWriter(), "  1. Work in each directory with different AI tools")
 	fmt.Fprintln(outWriter(), "  2. Evaluate and pick the best solution")
-	fmt.Fprintf(outWriter(), "  3. Run: gmc wt promote <worktree> <branch-name>\n")
-	fmt.Fprintln(outWriter(), "  4. Clean up: gmc wt rm <other-worktrees> -D")
+	fmt.Fprintf(outWriter(), "  3. Dry-run promote: gmc wt promote <candidate> --dry-run\n")
+	fmt.Fprintf(outWriter(), "  4. Promote winner: gmc wt promote <candidate>\n")
+	fmt.Fprintln(outWriter(), "  5. Clean up: gmc wt rm <other-worktrees> -D")
 
 	return nil
 }
 
-func runWorktreePromote(wtClient *worktree.Client, worktreeName, branchName string) error {
-	report, err := wtClient.Promote(worktreeName, branchName)
+func runWorktreePromote(wtClient *worktree.Client, candidate string) error {
+	report, err := wtClient.Promote(candidate, worktree.PromoteOptions{
+		DryRun: wtDryRun,
+	})
 	printWorktreeReport(report)
 	return err
 }

--- a/internal/worktree/dup_promote.go
+++ b/internal/worktree/dup_promote.go
@@ -1,0 +1,575 @@
+package worktree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/samzong/gmc/internal/gitcmd"
+	"github.com/samzong/gmc/internal/gitutil"
+)
+
+type PromoteOptions struct {
+	DryRun bool
+}
+
+type dupTaskFile struct {
+	source string
+	rel    string
+}
+
+type promotionPatch struct {
+	name string
+	data []byte
+}
+
+func (c *Client) resolveDupTaskFiles(parentRoot string, paths []string) ([]dupTaskFile, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	canonicalParentRoot, err := filepath.EvalSymlinks(parentRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve parent worktree path %s: %w", parentRoot, err)
+	}
+	canonicalParentRoot = filepath.Clean(canonicalParentRoot)
+
+	result := make([]dupTaskFile, 0, len(paths))
+	for _, raw := range paths {
+		path := strings.TrimSpace(raw)
+		if path == "" {
+			return nil, errors.New("task file path cannot be empty")
+		}
+		absPath := path
+		if !filepath.IsAbs(absPath) {
+			var err error
+			absPath, err = filepath.Abs(absPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve task file %s: %w", path, err)
+			}
+		}
+		absPath = filepath.Clean(absPath)
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect task file %s: %w", path, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("task path must be a file, not a directory: %s", path)
+		}
+		canonicalAbsPath, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve task file %s: %w", path, err)
+		}
+		rel, ok := relativePathWithin(canonicalParentRoot, canonicalAbsPath)
+		if !ok {
+			return nil, fmt.Errorf("task file must be inside parent worktree: %s", path)
+		}
+		result = append(result, dupTaskFile{source: absPath, rel: filepath.Clean(rel)})
+	}
+	return result, nil
+}
+
+func (c *Client) copyDupTaskFiles(files []dupTaskFile, targetRoot string) error {
+	for _, file := range files {
+		target := filepath.Join(targetRoot, file.rel)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("failed to create task file directory for %s: %w", file.rel, err)
+		}
+		if err := copyFile(file.source, target); err != nil {
+			return fmt.Errorf("failed to copy task file %s: %w", file.rel, err)
+		}
+	}
+	return nil
+}
+
+func relativePathFrom(base, target string) string {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return target
+	}
+	if rel == "." {
+		return "."
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return target
+	}
+	return rel
+}
+
+func (c *Client) Promote(candidate string, opts PromoteOptions) (Report, error) {
+	var report Report
+
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return report, errors.New("candidate worktree cannot be empty")
+	}
+	if err := c.ensureInit(); err != nil {
+		return report, fmt.Errorf("failed to determine worktree search root: %w", err)
+	}
+
+	parentRoot, err := c.currentTopLevelRequired()
+	if err != nil {
+		return report, err
+	}
+	candidatePath, err := c.resolvePromoteCandidate(candidate)
+	if err != nil {
+		return report, err
+	}
+	if sameCleanPath(parentRoot, candidatePath) {
+		return report, errors.New("candidate worktree must be different from the parent worktree")
+	}
+
+	untracked, err := c.untrackedFiles(candidatePath)
+	if err != nil {
+		return report, err
+	}
+	untracked, ignoredUntracked, err := filterExistingIdenticalFiles(parentRoot, candidatePath, untracked)
+	if err != nil {
+		return report, err
+	}
+	if rel, ok := relativePathWithin(parentRoot, candidatePath); ok {
+		ignoredUntracked = append(ignoredUntracked, rel)
+	}
+
+	clean, err := c.isWorktreeCleanIgnoringUntracked(parentRoot, ignoredUntracked)
+	if err != nil {
+		return report, err
+	}
+	if !clean {
+		return report, errors.New("parent worktree has uncommitted changes; clean it before promoting")
+	}
+
+	parentHead, err := c.gitOutput(parentRoot, "rev-parse", "HEAD")
+	if err != nil {
+		return report, err
+	}
+	candidateHead, err := c.gitOutput(candidatePath, "rev-parse", "HEAD")
+	if err != nil {
+		return report, err
+	}
+	mergeBase, err := c.gitOutput(parentRoot, "merge-base", parentHead, candidateHead)
+	if err != nil {
+		return report, fmt.Errorf("failed to find merge base between parent and candidate: %w", err)
+	}
+
+	patches, err := c.collectPromotionPatches(candidatePath, mergeBase)
+	if err != nil {
+		return report, err
+	}
+	files, err := c.collectPromotionFileNames(candidatePath, mergeBase, untracked)
+	if err != nil {
+		return report, err
+	}
+	if len(patches) == 0 && len(untracked) == 0 {
+		report.Info("No candidate changes to promote.")
+		return report, nil
+	}
+
+	if err := c.checkPromotion(parentHead, patches, candidatePath, untracked); err != nil {
+		return report, err
+	}
+	if opts.DryRun {
+		report.Info("Dry run successful.")
+		appendPromoteSummary(&report, parentRoot, candidatePath, files, true)
+		return report, nil
+	}
+
+	if err := c.preflightUntrackedCopies(parentRoot, untracked); err != nil {
+		return report, err
+	}
+	if err := applyPromotion(parentRoot, patches, candidatePath, untracked); err != nil {
+		return report, err
+	}
+
+	appendPromoteSummary(&report, parentRoot, candidatePath, files, false)
+	return report, nil
+}
+
+func (c *Client) currentTopLevelRequired() (string, error) {
+	root := c.currentTopLevel()
+	if root == "" {
+		return "", errors.New("failed to determine current worktree root")
+	}
+	return root, nil
+}
+
+func (c *Client) resolvePromoteCandidate(candidate string) (string, error) {
+	absCandidate := candidate
+	if !filepath.IsAbs(absCandidate) {
+		var err error
+		absCandidate, err = filepath.Abs(candidate)
+		if err != nil {
+			return c.resolveWorktreePath(candidate)
+		}
+	}
+	if absCandidate != "" {
+		worktrees, listErr := c.ListCached()
+		if listErr == nil {
+			for _, wt := range worktrees {
+				if sameCleanPath(wt.Path, absCandidate) {
+					return wt.Path, nil
+				}
+			}
+		}
+	}
+	return c.resolveWorktreePath(candidate)
+}
+
+func sameCleanPath(a, b string) bool {
+	cleanA := filepath.Clean(a)
+	cleanB := filepath.Clean(b)
+	evalA, errA := filepath.EvalSymlinks(cleanA)
+	if errA == nil {
+		cleanA = filepath.Clean(evalA)
+	}
+	evalB, errB := filepath.EvalSymlinks(cleanB)
+	if errB == nil {
+		cleanB = filepath.Clean(evalB)
+	}
+	return cleanA == cleanB
+}
+
+func relativePathWithin(base, target string) (string, bool) {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(target))
+	if err != nil || rel == "." || filepath.IsAbs(rel) || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.Clean(rel), true
+}
+
+func (c *Client) isWorktreeCleanIgnoringUntracked(path string, ignored []string) (bool, error) {
+	ignoredPaths := make([]string, 0, len(ignored))
+	for _, rel := range ignored {
+		ignoredPaths = append(ignoredPaths, filepath.Clean(rel))
+	}
+
+	result, err := c.runner.Run("-C", path, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return false, gitutil.WrapGitError("failed to inspect parent status", result, err)
+	}
+	for _, entry := range bytes.Split(result.Stdout, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		if len(entry) < 4 {
+			return false, nil
+		}
+		status := string(entry[:2])
+		name := filepath.Clean(string(entry[3:]))
+		if status == "??" && isIgnoredUntrackedPath(name, ignoredPaths) {
+			continue
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func isIgnoredUntrackedPath(name string, ignored []string) bool {
+	name = filepath.Clean(name)
+	for _, rel := range ignored {
+		if name == rel || strings.HasPrefix(name, rel+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) gitOutput(dir string, args ...string) (string, error) {
+	result, err := c.runner.Run(append([]string{"-C", dir}, args...)...)
+	if err != nil {
+		return "", gitutil.WrapGitError("failed to run git "+strings.Join(args, " "), result, err)
+	}
+	output := result.StdoutString(true)
+	if output == "" {
+		return "", fmt.Errorf("git %s returned empty output", strings.Join(args, " "))
+	}
+	return output, nil
+}
+
+func (c *Client) gitBytes(dir string, args ...string) ([]byte, error) {
+	result, err := c.runner.Run(append([]string{"-C", dir}, args...)...)
+	if err != nil {
+		return nil, gitutil.WrapGitError("failed to run git "+strings.Join(args, " "), result, err)
+	}
+	return result.Stdout, nil
+}
+
+func (c *Client) collectPromotionPatches(candidatePath, mergeBase string) ([]promotionPatch, error) {
+	specs := []struct {
+		name string
+		args []string
+	}{
+		{name: "committed changes", args: []string{"diff", "--binary", "--full-index", "-M", mergeBase + "..HEAD"}},
+		{name: "staged changes", args: []string{"diff", "--binary", "--full-index", "-M", "--cached"}},
+		{name: "unstaged changes", args: []string{"diff", "--binary", "--full-index", "-M"}},
+	}
+
+	var patches []promotionPatch
+	for _, spec := range specs {
+		data, err := c.gitBytes(candidatePath, spec.args...)
+		if err != nil {
+			return nil, err
+		}
+		if len(bytes.TrimSpace(data)) == 0 {
+			continue
+		}
+		patches = append(patches, promotionPatch{name: spec.name, data: data})
+	}
+	return patches, nil
+}
+
+func (c *Client) untrackedFiles(candidatePath string) ([]string, error) {
+	data, err := c.gitBytes(candidatePath, "ls-files", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	parts := bytes.Split(data, []byte{0})
+	files := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		path := filepath.Clean(string(part))
+		if path == "." || filepath.IsAbs(path) || strings.HasPrefix(path, ".."+string(filepath.Separator)) || path == ".." {
+			return nil, fmt.Errorf("unsafe untracked path: %s", string(part))
+		}
+		files = append(files, path)
+	}
+	return files, nil
+}
+
+func (c *Client) collectPromotionFileNames(candidatePath, mergeBase string, untracked []string) ([]string, error) {
+	specs := [][]string{
+		{"diff", "--name-only", "-M", mergeBase + "..HEAD"},
+		{"diff", "--name-only", "-M", "--cached"},
+		{"diff", "--name-only", "-M"},
+	}
+
+	var files []string
+	for _, args := range specs {
+		data, err := c.gitBytes(candidatePath, args...)
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			files = append(files, filepath.Clean(line))
+		}
+	}
+	files = append(files, untracked...)
+	return uniquePromotionFiles(files), nil
+}
+
+func uniquePromotionFiles(files []string) []string {
+	seen := make(map[string]struct{}, len(files))
+	var result []string
+	for _, file := range files {
+		if _, ok := seen[file]; ok {
+			continue
+		}
+		seen[file] = struct{}{}
+		result = append(result, file)
+	}
+	return result
+}
+
+func filterExistingIdenticalFiles(parentRoot, candidatePath string, files []string) ([]string, []string, error) {
+	filtered := make([]string, 0, len(files))
+	var ignored []string
+	for _, rel := range files {
+		same, err := sameRegularFileContent(filepath.Join(candidatePath, rel), filepath.Join(parentRoot, rel))
+		if err != nil {
+			return nil, nil, err
+		}
+		if same {
+			ignored = append(ignored, rel)
+			continue
+		}
+		filtered = append(filtered, rel)
+	}
+	return filtered, ignored, nil
+}
+
+func sameRegularFileContent(a, b string) (bool, error) {
+	aInfo, err := os.Lstat(a)
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect source file %s: %w", a, err)
+	}
+	if !aInfo.Mode().IsRegular() {
+		return false, nil
+	}
+
+	bInfo, err := os.Lstat(b)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to inspect destination file %s: %w", b, err)
+	}
+	if !bInfo.Mode().IsRegular() || aInfo.Size() != bInfo.Size() {
+		return false, nil
+	}
+
+	aFile, err := os.Open(a)
+	if err != nil {
+		return false, fmt.Errorf("failed to open source file %s: %w", a, err)
+	}
+	defer aFile.Close()
+
+	bFile, err := os.Open(b)
+	if err != nil {
+		return false, fmt.Errorf("failed to open destination file %s: %w", b, err)
+	}
+	defer bFile.Close()
+
+	aBuf := make([]byte, 32*1024)
+	bBuf := make([]byte, 32*1024)
+	for {
+		aN, aErr := aFile.Read(aBuf)
+		bN, bErr := bFile.Read(bBuf)
+		if aN != bN || !bytes.Equal(aBuf[:aN], bBuf[:bN]) {
+			return false, nil
+		}
+		if errors.Is(aErr, io.EOF) && errors.Is(bErr, io.EOF) {
+			return true, nil
+		}
+		if aErr != nil && !errors.Is(aErr, io.EOF) {
+			return false, fmt.Errorf("failed to read source file %s: %w", a, aErr)
+		}
+		if bErr != nil && !errors.Is(bErr, io.EOF) {
+			return false, fmt.Errorf("failed to read destination file %s: %w", b, bErr)
+		}
+	}
+}
+
+func (c *Client) checkPromotion(
+	parentHead string,
+	patches []promotionPatch,
+	candidatePath string,
+	untracked []string,
+) error {
+	tmpDir, err := os.MkdirTemp("", "gmc-promote-check-*")
+	if err != nil {
+		return fmt.Errorf("failed to create promote check temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	checkPath := filepath.Join(tmpDir, "worktree")
+	result, err := c.runner.RunLogged("-C", c.repoDir, "worktree", "add", "--detach", checkPath, parentHead)
+	if err != nil {
+		return gitutil.WrapGitError("failed to create promote check worktree", result, err)
+	}
+	defer func() {
+		_, _ = c.runner.Run("-C", c.repoDir, "worktree", "remove", "--force", checkPath)
+	}()
+
+	if err := applyPromotion(checkPath, patches, candidatePath, untracked); err != nil {
+		return fmt.Errorf("promotion patch does not apply cleanly: %w", err)
+	}
+	return nil
+}
+
+func applyPromotion(targetPath string, patches []promotionPatch, candidatePath string, untracked []string) error {
+	for _, patch := range patches {
+		if err := gitApply(targetPath, patch); err != nil {
+			return err
+		}
+	}
+	return copyUntrackedPromotionFiles(candidatePath, targetPath, untracked)
+}
+
+func gitApply(targetPath string, patch promotionPatch) error {
+	cmd := exec.Command("git", "-C", targetPath, "apply", "--3way", "--binary")
+	cmd.Stdin = bytes.NewReader(patch.data)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		result := gitcmd.Result{Stdout: out.Bytes(), Stderr: errOut.Bytes()}
+		return gitutil.WrapGitError("failed to apply "+patch.name, result, err)
+	}
+	return nil
+}
+
+func (c *Client) preflightUntrackedCopies(parentRoot string, untracked []string) error {
+	for _, rel := range untracked {
+		target := filepath.Join(parentRoot, rel)
+		if _, err := os.Lstat(target); err == nil {
+			return fmt.Errorf("cannot promote untracked file %s: destination already exists", rel)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to inspect destination for %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+func copyUntrackedPromotionFiles(candidatePath, targetPath string, untracked []string) error {
+	for _, rel := range untracked {
+		src := filepath.Join(candidatePath, rel)
+		dst := filepath.Join(targetPath, rel)
+		if _, err := os.Lstat(dst); err == nil {
+			return fmt.Errorf("cannot promote untracked file %s: destination already exists", rel)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to inspect destination for %s: %w", rel, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("failed to create destination directory for %s: %w", rel, err)
+		}
+		if err := copyPromotionFile(src, dst); err != nil {
+			return fmt.Errorf("failed to copy untracked file %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+func copyPromotionFile(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(target, dst)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("unsupported untracked file type: %s", src)
+	}
+	return copyFile(src, dst)
+}
+
+func appendPromoteSummary(report *Report, parentRoot, candidatePath string, files []string, dryRun bool) {
+	if dryRun {
+		report.Info("Would promote candidate: " + candidatePath)
+		report.Info("Parent worktree: " + parentRoot)
+	} else {
+		report.Info("Promoted candidate: " + candidatePath)
+		report.Info("Parent worktree: " + parentRoot)
+	}
+	if len(files) == 0 {
+		report.Info("Changed files: none")
+		return
+	}
+	report.Info("Changed files:")
+	for _, file := range files {
+		report.Info("  " + file)
+	}
+	if !dryRun {
+		report.Info("Next step: review changes in the parent worktree, then commit explicitly.")
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -742,13 +742,17 @@ func (c *Client) branchExists(name string) (bool, error) {
 type DupOptions struct {
 	BaseBranch string // Base branch to create from
 	Count      int    // Number of worktrees to create
+	TaskFiles  []string
 }
 
 // DupResult result of a dup operation
 type DupResult struct {
-	Worktrees []string // Created worktree directories
-	Branches  []string // Created branch names
-	Warnings  []string // Non-fatal warnings generated during creation
+	Worktrees     []string
+	WorktreePaths []string
+	RelativePaths []string
+	Branches      []string
+	TaskFiles     []string
+	Warnings      []string
 }
 
 func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
@@ -763,10 +767,34 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 		return nil, fmt.Errorf("failed to find worktree root: %w", err)
 	}
 
+	relativeBase := c.worktreeRoot
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		relativeBase = cwd
+	}
+	var taskFiles []dupTaskFile
+	var taskPaths []string
+	if len(opts.TaskFiles) > 0 {
+		parentRoot, err := c.currentTopLevelRequired()
+		if err != nil {
+			return nil, err
+		}
+		taskFiles, err = c.resolveDupTaskFiles(parentRoot, opts.TaskFiles)
+		if err != nil {
+			return nil, err
+		}
+		taskPaths = make([]string, 0, len(taskFiles))
+		for _, file := range taskFiles {
+			taskPaths = append(taskPaths, file.rel)
+		}
+	}
+
 	timestamp := strconv.FormatInt(getCurrentTimestamp(), 10)
 	dupResult := &DupResult{
-		Worktrees: make([]string, 0, opts.Count),
-		Branches:  make([]string, 0, opts.Count),
+		Worktrees:     make([]string, 0, opts.Count),
+		WorktreePaths: make([]string, 0, opts.Count),
+		RelativePaths: make([]string, 0, opts.Count),
+		Branches:      make([]string, 0, opts.Count),
+		TaskFiles:     taskPaths,
 	}
 
 	for i := 1; i <= opts.Count; i++ {
@@ -799,69 +827,19 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 				dupResult.Warnings = append(dupResult.Warnings, event.Message)
 			}
 		}
+		if err := c.copyDupTaskFiles(taskFiles, targetPath); err != nil {
+			return nil, err
+		}
 
 		dupResult.Worktrees = append(dupResult.Worktrees, dirName)
+		dupResult.WorktreePaths = append(dupResult.WorktreePaths, targetPath)
+		dupResult.RelativePaths = append(dupResult.RelativePaths, relativePathFrom(relativeBase, targetPath))
 		dupResult.Branches = append(dupResult.Branches, branchName)
 	}
 
 	c.InvalidateList()
 
 	return dupResult, nil
-}
-
-// Promote renames the branch of a worktree to a permanent name
-func (c *Client) Promote(worktreeName, newBranchName string) (Report, error) {
-	var report Report
-
-	if worktreeName == "" {
-		return report, errors.New("worktree name cannot be empty")
-	}
-	if newBranchName == "" {
-		return report, errors.New("branch name cannot be empty")
-	}
-
-	if err := gitutil.ValidateBranchName(newBranchName); err != nil {
-		return report, err
-	}
-
-	if err := c.ensureInit(); err != nil {
-		return report, fmt.Errorf("failed to determine worktree search root: %w", err)
-	}
-
-	targetPath := filepath.Join(c.searchRoot, worktreeName)
-
-	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
-		return report, fmt.Errorf("worktree not found: %s", worktreeName)
-	}
-
-	result, err := c.runner.Run("-C", targetPath, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return report, fmt.Errorf("failed to get current branch: %w", err)
-	}
-
-	oldBranch := result.StdoutString(true)
-	if oldBranch == "HEAD" {
-		return report, errors.New("worktree is in detached HEAD state, cannot promote")
-	}
-
-	pp, err := c.NewProtectionPolicy()
-	if err != nil {
-		return report, err
-	}
-	checkWt := Info{Path: targetPath, Branch: oldBranch}
-	if pp.IsProtected(checkWt) {
-		return report, fmt.Errorf("cannot promote protected worktree '%s' (%s)", worktreeName, pp.Reason(checkWt))
-	}
-
-	// Rename branch
-	args := []string{"-C", targetPath, "branch", "-m", newBranchName}
-	result, err = c.runner.RunLogged(args...)
-	if err != nil {
-		return report, gitutil.WrapGitError("failed to rename branch", result, err)
-	}
-
-	report.Info(fmt.Sprintf("Promoted '%s' -> '%s'", oldBranch, newBranchName))
-	return report, nil
 }
 
 // getCurrentTimestamp returns current unix timestamp

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -660,31 +660,298 @@ func TestRemoveProtectedWorktree(t *testing.T) {
 	}
 }
 
-func TestPromoteProtectedWorktree(t *testing.T) {
+func TestPromoteRejectsSameWorktreeCandidate(t *testing.T) {
 	repoDir := initTestRepo(t)
+	chdir(t, repoDir)
 
-	featureDir := filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"--feature")
-	runGit(t, repoDir, "worktree", "add", "-b", "feature", featureDir, "main")
-	defer os.RemoveAll(featureDir)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chdir(cwd) }()
-	if err := os.Chdir(featureDir); err != nil {
-		t.Fatal(err)
-	}
-
-	repoName := filepath.Base(repoDir)
 	client := NewClient(Options{})
-	_, err = client.Promote(repoName, "new-name")
+	_, err := client.Promote(repoDir, PromoteOptions{})
 	if err == nil {
-		t.Fatal("expected error when promoting protected worktree")
+		t.Fatal("expected error when promoting the current worktree")
 	}
-	if !strings.Contains(err.Error(), "cannot promote protected worktree") {
+	if !strings.Contains(err.Error(), "must be different from the parent") {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+func TestDupCopiesTaskFilesAndKeepsBareLayoutPath(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+	chdir(t, mainDir)
+
+	writeFile(t, filepath.Join(mainDir, "todo.md"), "task")
+
+	client := NewClient(Options{})
+	result, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1, TaskFiles: []string{"todo.md"}})
+	if err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+	if got, want := result.Worktrees[0], ".dup-1"; got != want {
+		t.Fatalf("Worktrees[0] = %q, want %q", got, want)
+	}
+	dupDir := filepath.Join(repoDir, ".dup-1")
+	if got, want := result.WorktreePaths[0], dupDir; !sameCleanPath(got, want) {
+		t.Fatalf("WorktreePaths[0] = %q, want %q", got, want)
+	}
+	if got, want := readFile(t, filepath.Join(dupDir, "todo.md")), "task"; got != want {
+		t.Fatalf("copied task = %q, want %q", got, want)
+	}
+}
+
+func TestDupWithoutTaskWorksFromBareLayoutRoot(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	chdir(t, repoDir)
+
+	client := NewClient(Options{})
+	result, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1})
+	if err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+	dupDir := filepath.Join(repoDir, ".dup-1")
+	if got, want := result.WorktreePaths[0], dupDir; !sameCleanPath(got, want) {
+		t.Fatalf("WorktreePaths[0] = %q, want %q", got, want)
+	}
+	if got, want := result.RelativePaths[0], ".dup-1"; got != want {
+		t.Fatalf("RelativePaths[0] = %q, want %q", got, want)
+	}
+}
+
+func TestDupRejectsTaskDirectory(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+	chdir(t, mainDir)
+	if err := os.Mkdir(filepath.Join(mainDir, "tasks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient(Options{})
+	_, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1, TaskFiles: []string{"tasks"}})
+	if err == nil {
+		t.Fatal("expected directory task error")
+	}
+	if !strings.Contains(err.Error(), "must be a file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDupAcceptsCanonicalTaskPath(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+	writeFile(t, filepath.Join(mainDir, "todo.md"), "task")
+
+	linkDir := filepath.Join(t.TempDir(), "main-link")
+	if err := os.Symlink(mainDir, linkDir); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Dup(DupOptions{
+		BaseBranch: "main",
+		Count:      1,
+		TaskFiles:  []string{filepath.Join(linkDir, "todo.md")},
+	}); err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+	assertFileContent(t, filepath.Join(repoDir, ".dup-1", "todo.md"), "task")
+}
+
+func TestPromoteAppliesCandidateChangesToCurrentParent(t *testing.T) {
+	repoDir, mainDir, dupDir := createPromoteCandidate(t)
+
+	writeFile(t, filepath.Join(dupDir, "committed.txt"), "committed")
+	runGit(t, dupDir, "add", "committed.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate commit")
+	writeFile(t, filepath.Join(dupDir, "staged.txt"), "staged")
+	runGit(t, dupDir, "add", "staged.txt")
+	writeFile(t, filepath.Join(dupDir, "README.md"), "candidate readme")
+	writeFile(t, filepath.Join(dupDir, "untracked.txt"), "untracked")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	report, err := client.Promote(".dup-1", PromoteOptions{})
+	if err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+	if len(report.Events) == 0 {
+		t.Fatal("expected report events")
+	}
+
+	assertFileContent(t, filepath.Join(mainDir, "committed.txt"), "committed")
+	assertFileContent(t, filepath.Join(mainDir, "staged.txt"), "staged")
+	assertFileContent(t, filepath.Join(mainDir, "README.md"), "candidate readme")
+	assertFileContent(t, filepath.Join(mainDir, "untracked.txt"), "untracked")
+	status := runGit(t, mainDir, "status", "--short")
+	for _, file := range []string{"committed.txt", "staged.txt", "README.md", "untracked.txt"} {
+		if !strings.Contains(status, file) {
+			t.Fatalf("status %q does not contain %s in repo %s", status, file, repoDir)
+		}
+	}
+}
+
+func TestPromoteDryRunLeavesParentUnchanged(t *testing.T) {
+	_, mainDir, dupDir := createPromoteCandidate(t)
+	writeFile(t, filepath.Join(dupDir, "candidate.txt"), "candidate")
+	runGit(t, dupDir, "add", "candidate.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Promote(".dup-1", PromoteOptions{DryRun: true}); err != nil {
+		t.Fatalf("Promote(DryRun) error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(mainDir, "candidate.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created candidate.txt, stat err = %v", err)
+	}
+}
+
+func TestPromoteRejectsDirtyParent(t *testing.T) {
+	_, mainDir, dupDir := createPromoteCandidate(t)
+	writeFile(t, filepath.Join(dupDir, "candidate.txt"), "candidate")
+	runGit(t, dupDir, "add", "candidate.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate")
+	writeFile(t, filepath.Join(mainDir, "local.txt"), "local")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Promote(".dup-1", PromoteOptions{}); err == nil {
+		t.Fatal("expected dirty parent error")
+	} else if !strings.Contains(err.Error(), "clean it before promoting") {
+		t.Fatalf("Promote() error = %v, want clean parent guidance", err)
+	}
+	if _, err := os.Stat(filepath.Join(mainDir, "candidate.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty parent promote created candidate.txt, stat err = %v", err)
+	}
+	assertFileContent(t, filepath.Join(mainDir, "local.txt"), "local")
+}
+
+func TestPromoteSkipsUnchangedCopiedTaskFile(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+	chdir(t, mainDir)
+
+	writeFile(t, filepath.Join(mainDir, "task.txt"), "task")
+
+	client := NewClient(Options{})
+	if _, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1, TaskFiles: []string{"task.txt"}}); err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+
+	dupDir := filepath.Join(repoDir, ".dup-1")
+	writeFile(t, filepath.Join(dupDir, "candidate.txt"), "candidate")
+	runGit(t, dupDir, "add", "candidate.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate")
+
+	report, err := client.Promote(".dup-1", PromoteOptions{})
+	if err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(mainDir, "task.txt"), "task")
+	assertFileContent(t, filepath.Join(mainDir, "candidate.txt"), "candidate")
+	for _, event := range report.Events {
+		if strings.Contains(event.Message, "task.txt") {
+			t.Fatalf("report unexpectedly included unchanged task file: %q", event.Message)
+		}
+	}
+}
+
+func TestPromoteWorksInNormalRepositoryWithNestedCandidate(t *testing.T) {
+	repoDir := initTestRepo(t)
+	chdir(t, repoDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1}); err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+
+	dupDir := filepath.Join(repoDir, ".dup-1")
+	writeFile(t, filepath.Join(dupDir, "candidate.txt"), "candidate")
+	runGit(t, dupDir, "add", "candidate.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate")
+
+	if _, err := client.Promote(".dup-1", PromoteOptions{}); err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+	assertFileContent(t, filepath.Join(repoDir, "candidate.txt"), "candidate")
+}
+
+func TestPromoteAppliesOntoAdvancedParent(t *testing.T) {
+	_, mainDir, dupDir := createPromoteCandidate(t)
+	writeFile(t, filepath.Join(dupDir, "candidate.txt"), "candidate")
+	runGit(t, dupDir, "add", "candidate.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate")
+	writeFile(t, filepath.Join(mainDir, "parent.txt"), "parent")
+	runGit(t, mainDir, "add", "parent.txt")
+	runGit(t, mainDir, "commit", "-m", "parent")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Promote(".dup-1", PromoteOptions{}); err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+	assertFileContent(t, filepath.Join(mainDir, "candidate.txt"), "candidate")
+	assertFileContent(t, filepath.Join(mainDir, "parent.txt"), "parent")
+}
+
+func TestPromoteTreatsAlreadyAppliedCandidateChangeAsNoop(t *testing.T) {
+	_, mainDir, dupDir := createPromoteCandidate(t)
+	writeFile(t, filepath.Join(dupDir, "same.txt"), "same")
+	writeFile(t, filepath.Join(dupDir, "new.txt"), "new")
+	runGit(t, dupDir, "add", "same.txt", "new.txt")
+	runGit(t, dupDir, "commit", "-m", "candidate")
+
+	writeFile(t, filepath.Join(mainDir, "same.txt"), "same")
+	runGit(t, mainDir, "add", "same.txt")
+	runGit(t, mainDir, "commit", "-m", "parent already has same")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Promote(".dup-1", PromoteOptions{}); err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+	assertFileContent(t, filepath.Join(mainDir, "same.txt"), "same")
+	assertFileContent(t, filepath.Join(mainDir, "new.txt"), "new")
+}
+
+func TestPromotePreservesUntrackedSymlink(t *testing.T) {
+	_, mainDir, dupDir := createPromoteCandidate(t)
+	writeFile(t, filepath.Join(dupDir, "target.txt"), "target")
+	if err := os.Symlink("target.txt", filepath.Join(dupDir, "link.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Promote(".dup-1", PromoteOptions{}); err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(mainDir, "link.txt"))
+	if err != nil {
+		t.Fatalf("Readlink() error = %v", err)
+	}
+	if target != "target.txt" {
+		t.Fatalf("link target = %q, want target.txt", target)
+	}
+	assertFileContent(t, filepath.Join(mainDir, "target.txt"), "target")
+}
+
+func TestPromoteConflictLeavesParentUnchanged(t *testing.T) {
+	_, mainDir, dupDir := createPromoteCandidate(t)
+	writeFile(t, filepath.Join(dupDir, "README.md"), "candidate")
+	runGit(t, dupDir, "add", "README.md")
+	runGit(t, dupDir, "commit", "-m", "candidate readme")
+	writeFile(t, filepath.Join(mainDir, "README.md"), "parent")
+	runGit(t, mainDir, "add", "README.md")
+	runGit(t, mainDir, "commit", "-m", "parent readme")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Promote(".dup-1", PromoteOptions{}); err == nil {
+		t.Fatal("expected conflict error")
+	}
+	assertFileContent(t, filepath.Join(mainDir, "README.md"), "parent")
 }
 
 func initTestRepo(t *testing.T) string {
@@ -728,6 +995,47 @@ func writeFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("writeFile(%s) failed: %v", path, err)
 	}
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readFile(%s) failed: %v", path, err)
+	}
+	return string(data)
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	if got := readFile(t, path); got != want {
+		t.Fatalf("%s = %q, want %q", path, got, want)
+	}
+}
+
+func createPromoteCandidate(t *testing.T) (string, string, string) {
+	t.Helper()
+	repoDir := initBareLayoutRepo(t)
+	mainDir := filepath.Join(repoDir, "main")
+	chdir(t, mainDir)
+
+	client := NewClient(Options{})
+	if _, err := client.Dup(DupOptions{BaseBranch: "main", Count: 1}); err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+	return repoDir, mainDir, filepath.Join(repoDir, ".dup-1")
 }
 
 func initBareLayoutRepo(t *testing.T) string {


### PR DESCRIPTION
### What's changed?

- Add `gmc wt dup --task` for copying task context files into duplicate candidates.
- Change `gmc wt promote` to apply the selected candidate back into the current parent worktree, with `--dry-run` support.
- Reject dirty parent worktrees and skip unchanged copied task files during promotion.

### Why

- Supports the parallel candidate workflow without hidden dirty-parent bypass behavior or branch-rename promotion semantics.