### PR TITLE
[Fix] Duplicate from current worktree

### DIFF
--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -181,7 +181,7 @@ Examples:
   # When one agent's solution wins, promote it into the current worktree:
   gmc wt promote .dup-1
 
-  # Defaults: count=2, base=main
+  # Defaults: count=2, base=current branch
   gmc wt dup
   gmc wt dup -b dev`,
 	Args: cobra.MaximumNArgs(1),
@@ -273,7 +273,7 @@ func init() {
 	wtCloneCmd.Flags().StringVar(&wtProjectName, "name", "", "Custom project directory name")
 
 	// Flags for dup command
-	wtDupCmd.Flags().StringVarP(&wtDupBase, "base", "b", "main", "Base branch to create from")
+	wtDupCmd.Flags().StringVarP(&wtDupBase, "base", "b", "", "Base branch to create from")
 	wtDupCmd.Flags().StringArrayVar(&wtDupTasks, "task", nil, "Task context file to copy into each candidate (repeatable)")
 
 	wtPromoteCmd.Flags().BoolVar(&wtDryRun, "dry-run", false,
@@ -760,7 +760,7 @@ func runWorktreeDup(wtClient *worktree.Client, args []string) error {
 		fmt.Fprintln(errWriter(), warning)
 	}
 
-	fmt.Fprintf(outWriter(), "Created %d worktrees based on '%s':\n", len(result.Worktrees), opts.BaseBranch)
+	fmt.Fprintf(outWriter(), "Created %d worktrees based on '%s':\n", len(result.Worktrees), result.BaseBranch)
 	for i, wt := range result.Worktrees {
 		relPath := wt
 		if i < len(result.RelativePaths) && result.RelativePaths[i] != "" {

--- a/internal/worktree/dup_promote.go
+++ b/internal/worktree/dup_promote.go
@@ -87,15 +87,18 @@ func (c *Client) copyDupTaskFiles(files []dupTaskFile, targetRoot string) error 
 }
 
 func relativePathFrom(base, target string) string {
+	if evalBase, err := filepath.EvalSymlinks(base); err == nil {
+		base = evalBase
+	}
+	if evalTarget, err := filepath.EvalSymlinks(target); err == nil {
+		target = evalTarget
+	}
 	rel, err := filepath.Rel(base, target)
 	if err != nil {
 		return target
 	}
 	if rel == "." {
 		return "."
-	}
-	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-		return target
 	}
 	return rel
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -753,12 +753,10 @@ type DupResult struct {
 	Branches      []string
 	TaskFiles     []string
 	Warnings      []string
+	BaseBranch    string
 }
 
 func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
-	if opts.BaseBranch == "" {
-		opts.BaseBranch = "HEAD"
-	}
 	if opts.Count < 1 {
 		opts.Count = 2
 	}
@@ -767,7 +765,10 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 		return nil, fmt.Errorf("failed to find worktree root: %w", err)
 	}
 
-	relativeBase := c.worktreeRoot
+	opts.BaseBranch = c.resolveDupBaseBranch(opts.BaseBranch)
+	targetRoot := c.dupTargetRoot()
+
+	relativeBase := targetRoot
 	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
 		relativeBase = cwd
 	}
@@ -795,12 +796,13 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 		RelativePaths: make([]string, 0, opts.Count),
 		Branches:      make([]string, 0, opts.Count),
 		TaskFiles:     taskPaths,
+		BaseBranch:    opts.BaseBranch,
 	}
 
 	for i := 1; i <= opts.Count; i++ {
 		dirName := fmt.Sprintf(".dup-%d", i)
 		branchName := fmt.Sprintf("_dup/%s/%s-%d", opts.BaseBranch, timestamp, i)
-		targetPath := filepath.Join(c.worktreeRoot, dirName)
+		targetPath := filepath.Join(targetRoot, dirName)
 
 		if _, err := os.Stat(targetPath); err == nil {
 			return nil, fmt.Errorf("directory already exists: %s", targetPath)
@@ -840,6 +842,31 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 	c.InvalidateList()
 
 	return dupResult, nil
+}
+
+func (c *Client) resolveDupBaseBranch(override string) string {
+	if override != "" {
+		return override
+	}
+	if currentRoot := c.currentTopLevel(); currentRoot != "" {
+		if branch := c.gitSymbolicRef(currentRoot, "HEAD"); branch != "" {
+			return branch
+		}
+		return "HEAD"
+	}
+	if c.repoDir != "" {
+		if branch := c.gitSymbolicRef(c.repoDir, "HEAD"); branch != "" {
+			return branch
+		}
+	}
+	return "HEAD"
+}
+
+func (c *Client) dupTargetRoot() string {
+	if currentRoot := c.currentTopLevel(); currentRoot != "" {
+		return filepath.Dir(currentRoot)
+	}
+	return c.worktreeRoot
 }
 
 // getCurrentTimestamp returns current unix timestamp

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -716,6 +716,44 @@ func TestDupWithoutTaskWorksFromBareLayoutRoot(t *testing.T) {
 	}
 }
 
+func TestDupDefaultsToCurrentWorktreeBranchAndSiblingPath(t *testing.T) {
+	repoDir := initTestRepo(t)
+	featureDir := filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"--feature-current")
+	runGit(t, repoDir, "worktree", "add", "-b", "feature/current", featureDir, "main")
+	var err error
+	featureDir, err = filepath.EvalSymlinks(featureDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(featureDir) })
+
+	writeFile(t, filepath.Join(featureDir, "feature.txt"), "feature")
+	runGit(t, featureDir, "add", "feature.txt")
+	runGit(t, featureDir, "commit", "-m", "feature")
+	chdir(t, featureDir)
+
+	client := NewClient(Options{})
+	result, err := client.Dup(DupOptions{Count: 1})
+	if err != nil {
+		t.Fatalf("Dup() error = %v", err)
+	}
+
+	dupDir := filepath.Join(filepath.Dir(featureDir), ".dup-1")
+	t.Cleanup(func() { _ = os.RemoveAll(dupDir) })
+	if got, want := result.BaseBranch, "feature/current"; got != want {
+		t.Fatalf("BaseBranch = %q, want %q", got, want)
+	}
+	if got, want := result.WorktreePaths[0], dupDir; !sameCleanPath(got, want) {
+		t.Fatalf("WorktreePaths[0] = %q, want %q", got, want)
+	}
+	if got, want := result.RelativePaths[0], "../.dup-1"; got != want {
+		t.Fatalf("RelativePaths[0] = %q, want %q", got, want)
+	}
+	if got, want := readFile(t, filepath.Join(dupDir, "feature.txt")), "feature"; got != want {
+		t.Fatalf("feature.txt = %q, want %q", got, want)
+	}
+}
+
 func TestDupRejectsTaskDirectory(t *testing.T) {
 	repoDir := initBareLayoutRepo(t)
 	mainDir := filepath.Join(repoDir, "main")
@@ -865,7 +903,7 @@ func TestPromoteWorksInNormalRepositoryWithNestedCandidate(t *testing.T) {
 		t.Fatalf("Dup() error = %v", err)
 	}
 
-	dupDir := filepath.Join(repoDir, ".dup-1")
+	dupDir := filepath.Join(filepath.Dir(repoDir), ".dup-1")
 	writeFile(t, filepath.Join(dupDir, "candidate.txt"), "candidate")
 	runGit(t, dupDir, "add", "candidate.txt")
 	runGit(t, dupDir, "commit", "-m", "candidate")


### PR DESCRIPTION
### What's changed?

- Default `gmc wt dup` to the current worktree branch when `--base` is omitted.
- Create duplicate worktrees as siblings of the current worktree.
- Add regression coverage for duplicating from a feature worktree.

### Why

- `gmc wt dup` should fan out from the operator's current working context instead of falling back to `main` or the original root worktree.