### PR TITLE
[Feat] Show worktree diff stats

### DIFF
--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -170,6 +170,42 @@ func TestRunWorktreeList_TextUnchanged(t *testing.T) {
 	assert.NotContains(t, output, `"name"`)
 }
 
+func TestRunWorktreeList_AppendsDiffStatToStatus(t *testing.T) {
+	repoDir := initCmdTestRepo(t)
+	linkedWt := filepath.Join(t.TempDir(), "feature-wt")
+	runGitCmd(t, repoDir, "worktree", "add", "-b", "feature/diff-check", linkedWt, "main")
+	require.NoError(t, os.WriteFile(filepath.Join(linkedWt, "feature.txt"), []byte("one\ntwo\n"), 0o644))
+	runGitCmd(t, linkedWt, "add", "feature.txt")
+	runGitCmd(t, linkedWt, "commit", "-m", "add feature")
+
+	oldCwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldCwd) }()
+	require.NoError(t, os.Chdir(repoDir))
+
+	var out bytes.Buffer
+	withWriters(t, &out, io.Discard)
+	withOutputFormat(t, "text")
+
+	client := worktree.NewClient(worktree.Options{})
+	err = runWorktreeList(client)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "feature/diff-check")
+	assert.Contains(t, output, "1 file (+2 -0)")
+	assert.NotContains(t, output, "clean, 1 file (+2 -0)")
+}
+
+func TestFormatWorktreeStatus(t *testing.T) {
+	stat := worktree.DiffStat{Files: 1, Insertions: 2}
+
+	assert.Equal(t, "clean", formatWorktreeStatus("clean", worktree.DiffStat{}, false))
+	assert.Equal(t, "1 file (+2 -0)", formatWorktreeStatus("clean", stat, true))
+	assert.Equal(t, "1 file changed, 1 file (+2 -0)", formatWorktreeStatus("1 file changed", stat, true))
+	assert.Equal(t, "agent", formatWorktreeStatus("agent", worktree.DiffStat{}, true))
+}
+
 func TestBuildWorktreeJSON_WithReviewStates(t *testing.T) {
 	repoDir := initCmdTestRepo(t)
 	oldCwd, err := os.Getwd()
@@ -178,11 +214,12 @@ func TestBuildWorktreeJSON_WithReviewStates(t *testing.T) {
 	require.NoError(t, os.Chdir(repoDir))
 
 	client := worktree.NewClient(worktree.Options{})
-	items := buildWorktreeJSON(client, []worktree.Info{{
+	wt := worktree.Info{
 		Path:   repoDir,
 		Branch: "feature/pr-json",
 		Commit: strings.Repeat("a", 40),
-	}}, map[string]worktree.ReviewInfo{
+	}
+	items := buildWorktreeJSON(client, []worktree.Info{wt}, map[string]worktree.ReviewInfo{
 		"feature/pr-json": {
 			Provider:   "github",
 			Number:     42,
@@ -190,9 +227,27 @@ func TestBuildWorktreeJSON_WithReviewStates(t *testing.T) {
 			HeadBranch: "feature/pr-json",
 			URL:        "https://github.com/example/repo/pull/42",
 		},
-	})
+	}, worktreeDiffStats{Stats: map[string]worktree.DiffStat{
+		repoDir: {
+			Base:       "main",
+			Files:      2,
+			Insertions: 4,
+		},
+	}})
 
 	require.Len(t, items, 1)
+	assert.Equal(t, "main", items[0].DiffBase)
+	require.NotNil(t, items[0].ChangedFiles)
+	require.NotNil(t, items[0].Insertions)
+	require.NotNil(t, items[0].Deletions)
+	assert.Equal(t, 2, *items[0].ChangedFiles)
+	assert.Equal(t, 4, *items[0].Insertions)
+	assert.Equal(t, 0, *items[0].Deletions)
+	assert.Equal(t, resolveWorktreeStatus(client, getDisplayRoot(client), wt), items[0].Status)
+	assert.NotEqual(t, "2 files (+4 -0)", items[0].Status)
+	data, err := json.Marshal(items[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"deletions":0`)
 	assert.Equal(t, "github", items[0].ReviewProvider)
 	assert.Equal(t, 42, items[0].ReviewNumber)
 	assert.Equal(t, "OPEN", items[0].ReviewState)
@@ -222,7 +277,7 @@ func TestPrintWorktreeTable_WithReviewStates(t *testing.T) {
 			HeadBranch: "feature/pr-text",
 			URL:        "https://github.com/example/repo/pull/42",
 		},
-	})
+	}, worktreeDiffStats{})
 
 	output := out.String()
 	assert.Contains(t, output, "PR")

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -27,6 +27,7 @@ var (
 	wtProjectName  string
 	prRemote       string
 	wtShowPR       bool
+	wtDiffBase     string
 )
 
 var wtCmd = &cobra.Command{
@@ -293,6 +294,10 @@ func init() {
 		"Show review request status for each branch (requires gh or glab CLI)")
 	wtListCmd.Flags().BoolVar(&wtShowPR, "pr", false,
 		"Show review request status for each branch (requires gh or glab CLI)")
+	wtCmd.Flags().StringVar(&wtDiffBase, "diff-base", "",
+		"Base branch/ref for worktree diff stats")
+	wtListCmd.Flags().StringVar(&wtDiffBase, "diff-base", "",
+		"Base branch/ref for worktree diff stats")
 
 	// Shell completions for arguments
 	wtRemoveCmd.ValidArgsFunction = completeWorktreeNames
@@ -303,6 +308,8 @@ func init() {
 	_ = wtDupCmd.RegisterFlagCompletionFunc("base", completeBranchNames)
 	_ = wtPruneCmd.RegisterFlagCompletionFunc("base", completeBranchNames)
 	_ = wtPrReviewCmd.RegisterFlagCompletionFunc("remote", completeRemoteNames)
+	_ = wtCmd.RegisterFlagCompletionFunc("diff-base", completeBranchNames)
+	_ = wtListCmd.RegisterFlagCompletionFunc("diff-base", completeBranchNames)
 
 	// Add to root command
 	rootCmd.AddCommand(wtCmd)
@@ -314,6 +321,10 @@ type WorktreeJSON struct {
 	Branch         string `json:"branch"`
 	Commit         string `json:"commit"`
 	Status         string `json:"status"`
+	DiffBase       string `json:"diff_base,omitempty"`
+	ChangedFiles   *int   `json:"changed_files,omitempty"`
+	Insertions     *int   `json:"insertions,omitempty"`
+	Deletions      *int   `json:"deletions,omitempty"`
 	ReviewProvider string `json:"review_provider,omitempty"`
 	ReviewNumber   int    `json:"review_number,omitempty"`
 	ReviewState    string `json:"review_state,omitempty"`
@@ -328,9 +339,13 @@ func runWorktreeDefault(wtClient *worktree.Client, _ *cobra.Command) error {
 
 	filtered := filterBareWorktrees(worktrees)
 	reviews := loadWorktreeReviews(wtClient, filtered)
+	diffStats, err := loadWorktreeDiffStats(wtClient, filtered)
+	if err != nil {
+		return err
+	}
 
 	if outputFormat() == "json" {
-		if err := printWorktreeJSON(wtClient, filtered, reviews.Reviews); err != nil {
+		if err := printWorktreeJSON(wtClient, filtered, reviews.Reviews, diffStats); err != nil {
 			return err
 		}
 		printReviewWarning(errWriter(), reviews)
@@ -338,7 +353,7 @@ func runWorktreeDefault(wtClient *worktree.Client, _ *cobra.Command) error {
 	}
 
 	fmt.Fprintln(outWriter(), "Current Worktrees:")
-	printWorktreeTable(wtClient, filtered, reviews.Reviews)
+	printWorktreeTable(wtClient, filtered, reviews.Reviews, diffStats)
 
 	cwd, err := os.Getwd()
 	if err == nil {
@@ -415,9 +430,13 @@ func runWorktreeList(wtClient *worktree.Client) error {
 
 	filtered := filterBareWorktrees(worktrees)
 	reviews := loadWorktreeReviews(wtClient, filtered)
+	diffStats, err := loadWorktreeDiffStats(wtClient, filtered)
+	if err != nil {
+		return err
+	}
 
 	if outputFormat() == "json" {
-		if err := printWorktreeJSON(wtClient, filtered, reviews.Reviews); err != nil {
+		if err := printWorktreeJSON(wtClient, filtered, reviews.Reviews, diffStats); err != nil {
 			return err
 		}
 		printReviewWarning(errWriter(), reviews)
@@ -429,7 +448,7 @@ func runWorktreeList(wtClient *worktree.Client) error {
 		return nil
 	}
 
-	printWorktreeTable(wtClient, filtered, reviews.Reviews)
+	printWorktreeTable(wtClient, filtered, reviews.Reviews, diffStats)
 	printReviewWarning(outWriter(), reviews)
 	return nil
 }
@@ -576,6 +595,56 @@ func resolveWorktreeStatus(wtClient *worktree.Client, root string, wt worktree.I
 	}
 }
 
+type worktreeDiffStats struct {
+	Stats map[string]worktree.DiffStat
+}
+
+func loadWorktreeDiffStats(wtClient *worktree.Client, worktrees []worktree.Info) (worktreeDiffStats, error) {
+	lookup := worktreeDiffStats{Stats: make(map[string]worktree.DiffStat)}
+	if len(worktrees) == 0 {
+		return lookup, nil
+	}
+
+	base, err := wtClient.ResolveDiffBase(wtDiffBase)
+	if err != nil {
+		if strings.TrimSpace(wtDiffBase) != "" {
+			return lookup, err
+		}
+		return lookup, nil
+	}
+
+	for _, wt := range worktrees {
+		stat, statErr := wtClient.WorktreeDiffStat(wt.Path, base)
+		if statErr != nil {
+			if strings.TrimSpace(wtDiffBase) != "" {
+				return lookup, statErr
+			}
+			continue
+		}
+		lookup.Stats[wt.Path] = stat
+	}
+	return lookup, nil
+}
+
+func formatWorktreeStatus(status string, stat worktree.DiffStat, ok bool) string {
+	if !ok || !stat.HasChanges() {
+		return status
+	}
+	diffStat := formatDiffStat(stat)
+	if status == "" || status == "clean" {
+		return diffStat
+	}
+	return status + ", " + diffStat
+}
+
+func formatDiffStat(stat worktree.DiffStat) string {
+	fileLabel := "files"
+	if stat.Files == 1 {
+		fileLabel = "file"
+	}
+	return fmt.Sprintf("%d %s (+%d -%d)", stat.Files, fileLabel, stat.Insertions, stat.Deletions)
+}
+
 func loadWorktreeReviews(wtClient *worktree.Client, worktrees []worktree.Info) worktree.ReviewLookup {
 	if !wtShowPR || len(worktrees) == 0 {
 		return worktree.ReviewLookup{}
@@ -633,7 +702,12 @@ func padVisibleRight(text string, visibleLen int, width int) string {
 	return text + strings.Repeat(" ", width-visibleLen)
 }
 
-func printWorktreeTable(wtClient *worktree.Client, worktrees []worktree.Info, reviews map[string]worktree.ReviewInfo) {
+func printWorktreeTable(
+	wtClient *worktree.Client,
+	worktrees []worktree.Info,
+	reviews map[string]worktree.ReviewInfo,
+	diffStats worktreeDiffStats,
+) {
 	if len(worktrees) == 0 {
 		return
 	}
@@ -680,7 +754,8 @@ func printWorktreeTable(wtClient *worktree.Client, worktrees []worktree.Info, re
 	for _, wt := range worktrees {
 		name := displayWorktreeName(root, wt.Path)
 		shortCommit := stringsutil.ShortHash(wt.Commit, 7, "")
-		status := resolveWorktreeStatus(wtClient, root, wt)
+		stat, hasStat := diffStats.Stats[wt.Path]
+		status := formatWorktreeStatus(resolveWorktreeStatus(wtClient, root, wt), stat, hasStat)
 		if reviews != nil {
 			prText := formatWorktreeReview(reviews, wt.Branch)
 			prDisplay := formatWorktreeReviewDisplay(reviews, wt.Branch, links)
@@ -703,16 +778,27 @@ func buildWorktreeJSON(
 	wtClient *worktree.Client,
 	worktrees []worktree.Info,
 	reviews map[string]worktree.ReviewInfo,
+	diffStats worktreeDiffStats,
 ) []WorktreeJSON {
 	root := getDisplayRoot(wtClient)
 	result := make([]WorktreeJSON, 0, len(worktrees))
 	for _, wt := range worktrees {
+		stat, hasStat := diffStats.Stats[wt.Path]
 		item := WorktreeJSON{
 			Name:   displayWorktreeName(root, wt.Path),
 			Path:   wt.Path,
 			Branch: wt.Branch,
 			Commit: wt.Commit,
 			Status: resolveWorktreeStatus(wtClient, root, wt),
+		}
+		if hasStat && stat.HasChanges() {
+			changedFiles := stat.Files
+			insertions := stat.Insertions
+			deletions := stat.Deletions
+			item.DiffBase = stat.Base
+			item.ChangedFiles = &changedFiles
+			item.Insertions = &insertions
+			item.Deletions = &deletions
 		}
 		if reviews != nil {
 			if review, ok := reviews[wt.Branch]; ok {
@@ -733,8 +819,9 @@ func printWorktreeJSON(
 	wtClient *worktree.Client,
 	worktrees []worktree.Info,
 	reviews map[string]worktree.ReviewInfo,
+	diffStats worktreeDiffStats,
 ) error {
-	return printJSON(outWriter(), buildWorktreeJSON(wtClient, worktrees, reviews))
+	return printJSON(outWriter(), buildWorktreeJSON(wtClient, worktrees, reviews, diffStats))
 }
 
 func runWorktreeDup(wtClient *worktree.Client, args []string) error {

--- a/docs/man/gmc-wt-list.1
+++ b/docs/man/gmc-wt-list.1
@@ -14,6 +14,10 @@ List all worktrees in the current repository.
 
 
 .SH OPTIONS
+\fB--diff-base\fP=""
+	Base branch/ref for worktree diff stats
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for list
 

--- a/docs/man/gmc-wt.1
+++ b/docs/man/gmc-wt.1
@@ -21,6 +21,10 @@ the base branch, and 'promote' to keep the winning solution.
 
 
 .SH OPTIONS
+\fB--diff-base\fP=""
+	Base branch/ref for worktree diff stats
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for wt
 

--- a/internal/worktree/diff_stat.go
+++ b/internal/worktree/diff_stat.go
@@ -1,0 +1,95 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type DiffStat struct {
+	Base       string
+	Files      int
+	Insertions int
+	Deletions  int
+}
+
+func (s DiffStat) HasChanges() bool {
+	return s.Files > 0
+}
+
+func (c *Client) ResolveDiffBase(override string) (string, error) {
+	if err := c.ensureInit(); err != nil {
+		return "", fmt.Errorf("failed to find worktree root: %w", err)
+	}
+	return c.resolveSyncBaseBranch(c.repoDir, override)
+}
+
+func (c *Client) WorktreeDiffStat(path, base string) (DiffStat, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return DiffStat{}, errors.New("diff base cannot be empty")
+	}
+
+	result, err := c.runner.Run("-C", path, "merge-base", base, "HEAD")
+	if err != nil {
+		return DiffStat{}, fmt.Errorf("failed to find merge base with %s: %w", base, err)
+	}
+	mergeBase := result.StdoutString(true)
+	if mergeBase == "" {
+		return DiffStat{}, fmt.Errorf("failed to find merge base with %s", base)
+	}
+
+	result, err = c.runner.Run("-C", path, "diff", "--numstat", "-z", mergeBase)
+	if err != nil {
+		return DiffStat{}, fmt.Errorf("failed to collect diff stat against %s: %w", mergeBase, err)
+	}
+
+	stat := parseDiffNumstat(result.Stdout)
+	stat.Base = base
+	return stat, nil
+}
+
+func parseDiffNumstat(output []byte) DiffStat {
+	var stat DiffStat
+	if len(output) == 0 {
+		return stat
+	}
+
+	fields := strings.Split(string(output), "\x00")
+	for i := 0; i < len(fields); {
+		field := fields[i]
+		if field == "" {
+			i++
+			continue
+		}
+
+		parts := strings.SplitN(field, "\t", 3)
+		if len(parts) < 3 {
+			i++
+			continue
+		}
+
+		stat.Files++
+		stat.Insertions += parseNumstatCount(parts[0])
+		stat.Deletions += parseNumstatCount(parts[1])
+
+		// With -z, renamed/copied paths are emitted as:
+		// "<adds>\t<dels>\t\0<old>\0<new>\0".
+		if parts[2] == "" {
+			i += 3
+			continue
+		}
+		i++
+	}
+
+	return stat
+}
+
+func parseNumstatCount(value string) int {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -255,6 +255,47 @@ func TestGetWorktreeStatus(t *testing.T) {
 	}
 }
 
+func TestWorktreeDiffStat(t *testing.T) {
+	repoDir := initTestRepo(t)
+	runGit(t, repoDir, "checkout", "-b", "feature/diff-stat")
+	writeFile(t, filepath.Join(repoDir, "feature.txt"), "one\ntwo\n")
+	runGit(t, repoDir, "add", "feature.txt")
+	runGit(t, repoDir, "commit", "-m", "add feature")
+
+	writeFile(t, filepath.Join(repoDir, "README.md"), "initial\nupdated\n")
+
+	client := NewClient(Options{})
+	stat, err := client.WorktreeDiffStat(repoDir, "main")
+	if err != nil {
+		t.Fatalf("WorktreeDiffStat() error = %v", err)
+	}
+
+	if stat.Files != 2 {
+		t.Errorf("Files = %d, want 2", stat.Files)
+	}
+	if stat.Insertions != 4 {
+		t.Errorf("Insertions = %d, want 4", stat.Insertions)
+	}
+	if stat.Deletions != 1 {
+		t.Errorf("Deletions = %d, want 1", stat.Deletions)
+	}
+}
+
+func TestParseDiffNumstatHandlesRename(t *testing.T) {
+	output := []byte("1\t0\t\x00old.txt\x00new.txt\x00")
+	stat := parseDiffNumstat(output)
+
+	if stat.Files != 1 {
+		t.Errorf("Files = %d, want 1", stat.Files)
+	}
+	if stat.Insertions != 1 {
+		t.Errorf("Insertions = %d, want 1", stat.Insertions)
+	}
+	if stat.Deletions != 0 {
+		t.Errorf("Deletions = %d, want 0", stat.Deletions)
+	}
+}
+
 func TestAddOptions(t *testing.T) {
 	opts := AddOptions{
 		BaseBranch: "main",


### PR DESCRIPTION
### What's changed?

- Add worktree diff stats against a resolved base branch to `gmc wt` and `gmc wt list`.
- Expose diff stat fields in JSON output and append stats to text status output.
- Add tests for diff stat collection, rename numstat parsing, text output, and JSON zero-count serialization.

### Why

- Worktree listings should show branch divergence without losing existing status semantics.