### PR TITLE
[Fix] worktree: use per-worktree upstream for diff stat base

### DIFF
--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -605,18 +605,20 @@ func loadWorktreeDiffStats(wtClient *worktree.Client, worktrees []worktree.Info)
 		return lookup, nil
 	}
 
-	base, err := wtClient.ResolveDiffBase(wtDiffBase)
-	if err != nil {
-		if strings.TrimSpace(wtDiffBase) != "" {
-			return lookup, err
-		}
-		return lookup, nil
-	}
+	override := strings.TrimSpace(wtDiffBase)
 
 	for _, wt := range worktrees {
+		base, baseErr := wtClient.ResolveDiffBaseForWorktree(wt.Path, wtDiffBase)
+		if baseErr != nil {
+			if override != "" {
+				return lookup, baseErr
+			}
+			continue
+		}
+
 		stat, statErr := wtClient.WorktreeDiffStat(wt.Path, base)
 		if statErr != nil {
-			if strings.TrimSpace(wtDiffBase) != "" {
+			if override != "" {
 				return lookup, statErr
 			}
 			continue

--- a/internal/worktree/diff_stat.go
+++ b/internal/worktree/diff_stat.go
@@ -25,6 +25,49 @@ func (c *Client) ResolveDiffBase(override string) (string, error) {
 	return c.resolveSyncBaseBranch(c.repoDir, override)
 }
 
+func (c *Client) ResolveDiffBaseForWorktree(path, override string) (string, error) {
+	if s := strings.TrimSpace(override); s != "" {
+		return s, nil
+	}
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("worktree path cannot be empty")
+	}
+	if up := c.branchUpstream(path); up != "" {
+		return up, nil
+	}
+	short, err := c.resolveSyncBaseBranch(path, "")
+	if err != nil {
+		return "", err
+	}
+	var candidates []string
+	if !strings.Contains(short, "/") {
+		candidates = append(candidates, "upstream/"+short, "origin/"+short, short)
+	} else {
+		parts := strings.SplitN(short, "/", 2)
+		for _, r := range []string{"upstream", "origin"} {
+			if r == parts[0] {
+				continue
+			}
+			candidates = append(candidates, r+"/"+parts[1])
+		}
+		candidates = append(candidates, short)
+	}
+	for _, ref := range candidates {
+		if c.gitRefExists(path, "refs/remotes/"+ref) {
+			return ref, nil
+		}
+	}
+	return short, nil
+}
+
+func (c *Client) branchUpstream(path string) string {
+	result, err := c.runner.Run("-C", path, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+	if err != nil {
+		return ""
+	}
+	return result.StdoutString(true)
+}
+
 func (c *Client) WorktreeDiffStat(path, base string) (DiffStat, error) {
 	base = strings.TrimSpace(base)
 	if base == "" {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -296,6 +296,62 @@ func TestParseDiffNumstatHandlesRename(t *testing.T) {
 	}
 }
 
+func TestResolveDiffBaseForWorktree_UsesBranchUpstream(t *testing.T) {
+	repoDir := initTestRepo(t)
+
+	runGit(t, repoDir, "checkout", "-b", "feature/upstream-tracked")
+	runGit(t, repoDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runGit(t, repoDir, "update-ref", "refs/heads/tracked-base", "HEAD")
+	runGit(t, repoDir, "branch", "--set-upstream-to=tracked-base")
+
+	client := NewClient(Options{})
+	base, err := client.ResolveDiffBaseForWorktree(repoDir, "")
+	if err != nil {
+		t.Fatalf("ResolveDiffBaseForWorktree() error = %v", err)
+	}
+	if base != "tracked-base" {
+		t.Errorf("ResolveDiffBaseForWorktree() = %q, want %q", base, "tracked-base")
+	}
+}
+
+func TestResolveDiffBaseForWorktree_FallsBackToRemoteRef(t *testing.T) {
+	repoDir := initTestRepo(t)
+
+	runGit(t, repoDir, "checkout", "-b", "feature/no-upstream")
+	runGit(t, repoDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+	client := NewClient(Options{})
+	base, err := client.ResolveDiffBaseForWorktree(repoDir, "")
+	if err != nil {
+		t.Fatalf("ResolveDiffBaseForWorktree() error = %v", err)
+	}
+	if base != "origin/main" {
+		t.Errorf("ResolveDiffBaseForWorktree() = %q, want %q", base, "origin/main")
+	}
+}
+
+// Regression: in CI the client singleton's repoDir (the gmc checkout) is
+// often on a detached PR ref with no `refs/heads/main`. The per-worktree
+// resolver must derive the base from the worktree path itself, not the
+// caller's repoDir.
+func TestResolveDiffBaseForWorktree_DoesNotDependOnClientRepoDir(t *testing.T) {
+	repoDir := initTestRepo(t)
+
+	runGit(t, repoDir, "checkout", "-b", "feature/no-upstream")
+	runGit(t, repoDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+	client := NewClient(Options{})
+	client.repoDir = t.TempDir()
+
+	base, err := client.ResolveDiffBaseForWorktree(repoDir, "")
+	if err != nil {
+		t.Fatalf("ResolveDiffBaseForWorktree() error = %v", err)
+	}
+	if base != "origin/main" {
+		t.Errorf("ResolveDiffBaseForWorktree() = %q, want %q", base, "origin/main")
+	}
+}
+
 func TestAddOptions(t *testing.T) {
 	opts := AddOptions{
 		BaseBranch: "main",


### PR DESCRIPTION
### What's changed?

- Add `ResolveDiffBaseForWorktree(path, override)` that resolves the diff base per worktree.
- New helper `branchUpstream(path)` reads `branch@{upstream}` — the per-branch truth git itself records.
- Fallback order: branch upstream → `upstream/<base>` → `origin/<base>` → local short name.
- `loadWorktreeDiffStats` now resolves the base inside the per-worktree loop instead of once for the whole repo.
- Two new unit tests cover the upstream-tracked and no-upstream paths.

### Why

`gmc wt list` (PR #77) was calling `resolveSyncBaseBranch` once and feeding the resulting short name (e.g. `main`) to every worktree. In fork setups with both `origin` and `upstream`, this short name resolved to a stale local `refs/heads/main`, so the diff stat was computed against an ancient ancestor and produced wildly inflated numbers — e.g. a 17-file real diff on `~/git/openclaw` was reported as 3223 files / +116k / -41k.

The previous function `resolveSyncBaseBranch` is unchanged and still backs `gmc wt sync`, where the upstream/remote selection is done in a separate step.