### PR TITLE
[Fix] Reuse add naming for PR worktrees

### DIFF
--- a/internal/formatter/diff_truncator.go
+++ b/internal/formatter/diff_truncator.go
@@ -229,31 +229,31 @@ func splitRenamePath(path string) (string, string, bool) {
 	}
 
 	if strings.Contains(path, "{") && strings.Contains(path, "}") {
-		oldPath := ""
-		newPath := ""
+		var oldPath strings.Builder
+		var newPath strings.Builder
 		rest := path
 		for {
 			start := strings.Index(rest, "{")
 			end := strings.Index(rest, "}")
 			if start == -1 || end == -1 || end < start {
-				oldPath += rest
-				newPath += rest
+				oldPath.WriteString(rest)
+				newPath.WriteString(rest)
 				break
 			}
-			oldPath += rest[:start]
-			newPath += rest[:start]
+			oldPath.WriteString(rest[:start])
+			newPath.WriteString(rest[:start])
 			segment := rest[start+1 : end]
 			parts := strings.SplitN(segment, "=>", 2)
 			if len(parts) != 2 {
-				oldPath += "{" + segment + "}"
-				newPath += "{" + segment + "}"
+				oldPath.WriteString("{" + segment + "}")
+				newPath.WriteString("{" + segment + "}")
 			} else {
-				oldPath += strings.TrimSpace(parts[0])
-				newPath += strings.TrimSpace(parts[1])
+				oldPath.WriteString(strings.TrimSpace(parts[0]))
+				newPath.WriteString(strings.TrimSpace(parts[1]))
 			}
 			rest = rest[end+1:]
 		}
-		return strings.TrimSpace(oldPath), strings.TrimSpace(newPath), true
+		return strings.TrimSpace(oldPath.String()), strings.TrimSpace(newPath.String()), true
 	}
 
 	parts := strings.SplitN(path, "=>", 2)

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -213,7 +213,7 @@ func TestConnection(model string) error {
 func buildVersionPrompt(baseVersion string, commits []string) string {
 	var builder strings.Builder
 	for i, commit := range commits {
-		builder.WriteString(fmt.Sprintf("%d. %s\n", i+1, strings.TrimSpace(commit)))
+		fmt.Fprintf(&builder, "%d. %s\n", i+1, strings.TrimSpace(commit))
 	}
 
 	return fmt.Sprintf(`Current version: %s

--- a/internal/worktree/pr.go
+++ b/internal/worktree/pr.go
@@ -3,8 +3,6 @@ package worktree
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/samzong/gmc/internal/gitutil"
@@ -88,35 +86,30 @@ func (c *Client) AddPR(prNumber int, remote string) (Report, error) {
 		return report, fmt.Errorf("PR #%d not found on remote '%s'", prNumber, remote)
 	}
 
-	// Prepare worktree paths
-	branchName := fmt.Sprintf("pr-%d", prNumber)
-	targetPath := filepath.Join(c.worktreeRoot, branchName)
-
-	if _, err := os.Stat(targetPath); err == nil {
-		return report, fmt.Errorf("directory already exists: %s", targetPath)
+	branchName := fmt.Sprintf("pr/%d", prNumber)
+	ctx, err := c.prepareAdd(branchName, AddOptions{})
+	if err != nil {
+		return report, err
 	}
 
-	// Fetch PR from remote
 	refSpec := fmt.Sprintf("pull/%d/head:%s", prNumber, branchName)
 	report.Info(fmt.Sprintf("Fetching PR #%d from %s...", prNumber, remote))
 
-	fetchArgs := []string{"-C", repoDir, "fetch", remote, refSpec}
-	result, err := c.runner.RunLogged(fetchArgs...)
+	result, err := c.runner.RunLogged("-C", ctx.repoDir, "fetch", remote, refSpec)
 	if err != nil {
 		return report, gitutil.WrapGitError("failed to fetch PR", result, err)
 	}
 
-	// Create worktree
-	addArgs := []string{"-C", repoDir, "worktree", "add", targetPath, branchName}
+	addArgs, _ := c.addArgs(ctx)
 	result, err = c.runner.RunLogged(addArgs...)
 	if err != nil {
 		return report, gitutil.WrapGitError("failed to create worktree", result, err)
 	}
-	if err := c.ensureAddedWorktreeConfig(targetPath); err != nil {
+	if err := c.ensureAddedWorktreeConfig(ctx.targetPath); err != nil {
 		return report, err
 	}
 
-	sharedReport, err := c.syncSharedResourcesToPath(targetPath, true)
+	sharedReport, err := c.syncSharedResourcesToPath(ctx.targetPath, true)
 	report.Merge(sharedReport)
 	if err != nil {
 		report.Warn(fmt.Sprintf("Warning: failed to sync shared resources: %v", err))
@@ -124,9 +117,9 @@ func (c *Client) AddPR(prNumber int, remote string) (Report, error) {
 
 	c.InvalidateList()
 
-	report.Info(fmt.Sprintf("Created PR worktree '%s' at %s", branchName, targetPath))
+	report.Info(fmt.Sprintf("Created PR worktree '%s' at %s", branchName, ctx.targetPath))
 	report.Info("Commit: " + commitHash[:7])
-	report.Info("Next step: cd " + targetPath)
+	report.Info("Next step: cd " + ctx.targetPath)
 
 	return report, nil
 }

--- a/internal/worktree/pr_test.go
+++ b/internal/worktree/pr_test.go
@@ -1,0 +1,53 @@
+package worktree
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAddPRUsesAddWorktreeNaming(t *testing.T) {
+	repoDir := initBareLayoutRepo(t)
+	runGit(t, filepath.Join(repoDir, ".bare"), "remote", "add", "origin", initPRRemote(t, 42))
+	chdir(t, filepath.Join(repoDir, "main"))
+
+	client := NewClient(Options{})
+	if _, err := client.AddPR(42, ""); err != nil {
+		t.Fatalf("AddPR() error = %v", err)
+	}
+
+	prDir := filepath.Join(repoDir, "pr--42")
+	status := runGit(t, prDir, "status", "--short", "--branch")
+	if !strings.Contains(status, "## pr/42") {
+		t.Fatalf("new worktree status = %q, want pr/42 branch", status)
+	}
+}
+
+func TestAddPRUsesAddWorktreeNamingInNormalRepo(t *testing.T) {
+	repoDir := initTestRepo(t)
+	runGit(t, repoDir, "remote", "add", "origin", initPRRemote(t, 42))
+	chdir(t, repoDir)
+
+	client := NewClient(Options{})
+	if _, err := client.AddPR(42, ""); err != nil {
+		t.Fatalf("AddPR() error = %v", err)
+	}
+
+	prDir := filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"--pr--42")
+	status := runGit(t, prDir, "status", "--short", "--branch")
+	if !strings.Contains(status, "## pr/42") {
+		t.Fatalf("new worktree status = %q, want pr/42 branch", status)
+	}
+}
+
+func initPRRemote(t *testing.T, prNumber int) string {
+	t.Helper()
+	remoteDir := initTestRepo(t)
+	runGit(t, remoteDir, "checkout", "-b", "feature/review")
+	writeFile(t, filepath.Join(remoteDir, "review.txt"), "review")
+	runGit(t, remoteDir, "add", ".")
+	runGit(t, remoteDir, "commit", "-m", "review")
+	runGit(t, remoteDir, "update-ref", fmt.Sprintf("refs/pull/%d/head", prNumber), "HEAD")
+	return remoteDir
+}


### PR DESCRIPTION
### What's changed?

- Reuse the standard worktree add path and branch naming for PR worktrees.
- Create PR branches as pr/<number> while preserving sanitized worktree directory names.
- Add coverage for PR worktree creation in bare-layout and normal repositories.
- Address lint findings in formatter rename parsing and LLM version prompt construction.

### Why

- Keeps PR worktree behavior consistent with regular worktree add behavior and restores the full make check gate.