### PR TITLE
feat(worktree): add global preparation rules and improve discovery

### DIFF
--- a/cmd/worktree_client.go
+++ b/cmd/worktree_client.go
@@ -1,7 +1,10 @@
 package cmd
 
-import "github.com/samzong/gmc/internal/worktree"
+import (
+	"github.com/samzong/gmc/internal/config"
+	"github.com/samzong/gmc/internal/worktree"
+)
 
 func newWorktreeClient() *worktree.Client {
-	return worktree.NewClient(worktree.Options{Verbose: verbose})
+	return worktree.NewClient(worktree.Options{Verbose: verbose, GlobalConfigPath: config.FilePath()})
 }

--- a/cmd/worktree_hook.go
+++ b/cmd/worktree_hook.go
@@ -11,97 +11,165 @@ import (
 
 var wtHookCmd = &cobra.Command{
 	Use:   "hook",
-	Short: "Manage hooks executed after worktree creation",
-	Long: `Manage hooks that are executed after shared resources are synced to a new worktree.
+	Short: "Manage hooks after worktree creation",
+	Long: `Manage commands run in a new worktree after shared resources are prepared.
 
-Hooks run in the target worktree directory and are useful for running
-package installation commands like 'pnpm install'.
-
-Config file is stored at the repository's shared git common dir
-(for example .git/gmc-share.yml or .bare/gmc-share.yml).`,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		wtClient := newWorktreeClient()
-		return runHookList(wtClient)
+Global defaults live under worktree.hooks in the selected gmc config file.
+Repository hooks live alongside shared resources in gmc-share.yml. Give a hook an
+ID to replace or disable it in a repository. Hooks run in effective list order.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runHookListCommand(cmd, newWorktreeClient())
 	},
 }
 
 var wtHookAddCmd = &cobra.Command{
 	Use:   "add <command>",
-	Short: "Add a hook to run after worktree creation",
-	Long: `Add a hook command that will be executed after shared resources are synced to a worktree.
+	Short: "Add or replace a worktree hook",
+	Long: `Configure a command executed after sharing during worktree creation.
 
-Hooks are executed in the target worktree directory after resources are synced.
-This is useful for running package installation commands like 'pnpm install'.
-
-Example:
-  gmc wt hook add "pnpm install" -d "Install dependencies"
-  gmc wt hook add "pnpm install && pnpm build"`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		wtClient := newWorktreeClient()
-		hook := worktree.Hook{
-			Cmd:  args[0],
-			Desc: hookDesc,
+A repository hook with the same ID replaces an inherited global hook. Global
+commands run in every repository; use shell conditions for project-specific work.
+Adding a hook does not execute it.`,
+	Example: "  gmc wt hook add 'pnpm install' --id install --desc 'Install dependencies'\n" +
+		"  gmc wt hook add 'test ! -f uv.lock || uv sync' --id python --global",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := newWorktreeClient()
+		id, _ := cmd.Flags().GetString("id")
+		hook := worktree.Hook{ID: id, Cmd: args[0], Desc: hookDesc}
+		global, _ := cmd.Flags().GetBool("global")
+		var report worktree.Report
+		var err error
+		if global {
+			report, err = client.AddGlobalHook(hook)
+		} else {
+			report, err = client.AddHook(hook)
 		}
-		report, err := wtClient.AddHook(hook)
-		printWorktreeReport(report)
+		printPreparationReport(report)
 		return err
 	},
 }
 
 var wtHookRemoveCmd = &cobra.Command{
-	Use:   "remove <index>",
-	Short: "Remove a hook by index",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		wtClient := newWorktreeClient()
-		index, err := strconv.Atoi(strings.TrimSpace(args[0]))
-		if err != nil {
-			return fmt.Errorf("invalid hook index: %s", args[0])
+	Use:     "remove <index-or-id>",
+	Aliases: []string{"rm"},
+	Short:   "Remove or disable a hook",
+	Long: `Remove a hook by its ID or the one-based index shown by hook list.
+
+Repository removal also disables an inherited global hook. With --global, use
+the index from hook list --global to remove a global default.`,
+	Example:           "  gmc wt hook remove install\n  gmc wt hook remove 1 --global",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeHooks,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := newWorktreeClient()
+		global, _ := cmd.Flags().GetBool("global")
+		value := strings.TrimSpace(args[0])
+		index, parseErr := strconv.Atoi(value)
+		var report worktree.Report
+		var err error
+		if parseErr != nil {
+			report, err = client.RemoveHookByID(value, global)
+		} else if global {
+			report, err = client.RemoveGlobalHook(index - 1)
+		} else {
+			report, err = client.RemoveHook(index - 1)
 		}
-		report, err := wtClient.RemoveHook(index - 1)
-		printWorktreeReport(report)
+		printPreparationReport(report)
 		return err
 	},
 }
 
-func runHookList(c *worktree.Client) error {
-	cfg, _, err := c.LoadSharedConfig()
+var wtHookListCmd = &cobra.Command{
+	Use:               "list",
+	Aliases:           []string{"ls"},
+	Short:             "List effective hooks in execution order",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runHookListCommand(cmd, newWorktreeClient())
+	},
+}
+
+type HookJSON struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id,omitempty"`
+	Cmd      string `json:"cmd"`
+	Desc     string `json:"desc,omitempty"`
+	Origin   string `json:"origin"`
+	Disabled bool   `json:"disabled"`
+}
+
+func hookJSON(hooks []worktree.Hook) []HookJSON {
+	items := make([]HookJSON, len(hooks))
+	for i, hook := range hooks {
+		items[i] = HookJSON{
+			Index: i + 1, ID: hook.ID, Cmd: hook.Cmd, Desc: hook.Desc, Origin: hook.Origin, Disabled: hook.Disabled,
+		}
+	}
+	return items
+}
+
+func runHookListCommand(cmd *cobra.Command, c *worktree.Client) error {
+	global, _ := cmd.Flags().GetBool("global")
+	cfg, err := loadListedSharedConfig(c, global)
 	if err != nil {
 		return err
 	}
-
-	if len(cfg.Hooks) == 0 {
-		fmt.Println("No hooks configured.")
-		return nil
+	if outputFormat() == "json" {
+		return printJSON(cmd.OutOrStdout(), hookJSON(cfg.Hooks))
 	}
-
-	fmt.Println("Hooks:")
-	for i, hook := range cfg.Hooks {
-		if hook.Desc != "" {
-			fmt.Printf("  %d. %s (%s)\n", i+1, hook.Cmd, hook.Desc)
-		} else {
-			fmt.Printf("  %d. %s\n", i+1, hook.Cmd)
-		}
-	}
+	printHooks(cmd, cfg.Hooks)
 	return nil
 }
 
-var (
-	hookDesc string
-)
+func printHooks(cmd *cobra.Command, hooks []worktree.Hook) {
+	if len(hooks) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No hooks configured.")
+		return
+	}
+	for i, hook := range hooks {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s [%s%s]", i+1, hook.Cmd, hook.Origin, disabledSuffix(hook.Disabled))
+		if hook.ID != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), " id=%s", hook.ID)
+		}
+		if hook.Desc != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), " (%s)", hook.Desc)
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+}
+
+func completeHooks(cmd *cobra.Command, args []string, prefix string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	global, _ := cmd.Flags().GetBool("global")
+	cfg, err := loadListedSharedConfig(newWorktreeClient(), global)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var values []string
+	for i, hook := range cfg.Hooks {
+		value := hook.ID
+		if value == "" {
+			value = strconv.Itoa(i + 1)
+		}
+		if strings.HasPrefix(value, prefix) {
+			values = append(values, value)
+		}
+	}
+	return values, cobra.ShellCompDirectiveNoFileComp
+}
+
+var hookDesc string
 
 func init() {
 	wtCmd.AddCommand(wtHookCmd)
-	wtHookCmd.AddCommand(wtHookAddCmd)
-	wtHookCmd.AddCommand(wtHookRemoveCmd)
-	wtHookCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		fmt.Println(cmd.Long)
-		fmt.Println("\nAvailable commands:")
-		fmt.Println("  add     Add a hook to run after worktree creation")
-		fmt.Println("  remove  Remove a hook by index")
-		fmt.Println("\nUse \"gmc wt hook [command] --help\" for more info.")
-	})
-
+	wtHookCmd.AddCommand(wtHookAddCmd, wtHookRemoveCmd, wtHookListCmd)
+	wtHookCmd.PersistentFlags().Bool("global", false, "Use defaults in the selected gmc config file")
 	wtHookAddCmd.Flags().StringVarP(&hookDesc, "desc", "d", "", "Description for the hook")
+	wtHookAddCmd.Flags().String("id", "", "Stable hook ID for repository overrides and removal")
 }

--- a/cmd/worktree_share.go
+++ b/cmd/worktree_share.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,94 +20,117 @@ var (
 var wtShareCmd = &cobra.Command{
 	Use:   "share",
 	Short: "Manage shared resources for worktrees",
-	Long: `Manage shared resources that are automatically synced to all worktrees.
+	Long: `Manage resources prepared before hooks run in new worktrees.
 
-If run without arguments, it opens an interactive mode to manage resources.
-
-Config file is stored at the repository's shared git common dir
-(for example .git/gmc-share.yml or .bare/gmc-share.yml).`,
+Global defaults live under worktree in the selected gmc config file.
+Repository rules in the git common dir's gmc-share.yml override global paths.
+Run without arguments for interactive repository management.`,
+	Example: "  gmc wt share discover\n  gmc wt share list --global",
+	Args:    cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		wtClient := newWorktreeClient()
-		return runWorktreeShareInteractive(wtClient)
+		return runWorktreeShareInteractive(newWorktreeClient())
 	},
 }
 
 var wtShareAddCmd = &cobra.Command{
 	Use:   "add <path>",
 	Short: "Add or update a shared resource",
-	Long: `Add a file or directory to be shared across all worktrees.
+	Long: `Add a file or directory shared across worktrees in each repository.
 
-Strategies:
-  - copy: Copies the file/directory (good for .env files that need isolation)
-  - link: Creates a symlink (good for large model directories)`,
-	Args: cobra.ExactArgs(1),
+copy creates an independent copy; link shares a writable source through a symlink.
+Global defaults apply when creating worktrees. Adding a global rule does not sync
+existing worktrees. Run share sync in a repository to apply its effective rules.
+Global and pattern rules use the primary worktree as their source, never a
+directory found only in another linked worktree.
+
+Quote patterns such as '**/.local' to match nested project paths. Pattern scans
+skip dependency, build, and .local directory interiors. Linking dependency environments
+shares writable state across branches; prefer package-manager caches where possible.`,
+	Example: "  gmc wt share add .env --strategy copy\n" +
+		"  gmc wt share add .local --strategy link --global\n" +
+		"  gmc wt share add '**/node_modules' --strategy link --global",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: cobra.FixedCompletions(nil, cobra.ShellCompDirectiveDefault),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		wtClient := newWorktreeClient()
-
+		client := newWorktreeClient()
 		strategy := worktree.ResourceStrategy(shareStrategy)
-		// If strategy not explicitly set via flag, ask interactively
 		if !cmd.Flags().Changed("strategy") {
 			strategy = promptStrategy(bufio.NewReader(os.Stdin))
 		}
-
-		report, err := wtClient.AddSharedResource(args[0], strategy)
-		printWorktreeReport(report)
+		global, _ := cmd.Flags().GetBool("global")
+		if global {
+			report, err := client.AddGlobalSharedResource(args[0], strategy)
+			printPreparationReport(report)
+			return err
+		}
+		report, err := client.AddSharedResource(args[0], strategy)
+		printPreparationReport(report)
 		if err != nil {
 			return err
 		}
-		return askToSyncAll(wtClient)
+		return askToSyncAll(client)
 	},
 }
 
 var wtShareRemoveCmd = &cobra.Command{
 	Use:     "remove <path>",
 	Aliases: []string{"rm"},
-	Short:   "Remove a shared resource from config",
-	Args:    cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		wtClient := newWorktreeClient()
-		report, err := wtClient.RemoveSharedResource(args[0])
-		printWorktreeReport(report)
-		if err != nil {
-			return err
+	Short:   "Remove or disable a shared resource",
+	Long: `Remove a repository rule and disable any inherited global rule for that path.
+Use --global to remove a global default. Existing files are preserved.`,
+	Example:           "  gmc wt share remove .local\n  gmc wt share remove .local --global",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeSharedResources,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := newWorktreeClient()
+		global, _ := cmd.Flags().GetBool("global")
+		var report worktree.Report
+		var err error
+		if global {
+			report, err = client.RemoveGlobalSharedResource(args[0])
+		} else {
+			report, err = client.RemoveSharedResource(args[0])
 		}
-		fmt.Println("Note: This does not remove the files from existing worktrees, only from the config.")
-		return nil
+		printPreparationReport(report)
+		if err == nil {
+			fmt.Fprintln(errWriter(), "Existing files are preserved.")
+		}
+		return err
 	},
 }
 
 type ShareJSON struct {
 	Path     string `json:"path"`
 	Strategy string `json:"strategy"`
+	Origin   string `json:"origin"`
+	Disabled bool   `json:"disabled"`
 }
 
 var wtShareListCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"ls"},
-	Short:   "List configured shared resources",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		wtClient := newWorktreeClient()
-		cfg, _, err := wtClient.LoadSharedConfig()
+	Use:               "list",
+	Aliases:           []string{"ls"},
+	Short:             "List effective shared resources",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		global, _ := cmd.Flags().GetBool("global")
+		cfg, err := loadListedSharedConfig(newWorktreeClient(), global)
 		if err != nil {
 			return err
 		}
-
 		if outputFormat() == "json" {
 			items := make([]ShareJSON, len(cfg.Resources))
 			for i, res := range cfg.Resources {
-				items[i] = ShareJSON{Path: res.Path, Strategy: string(res.Strategy)}
+				items[i] = ShareJSON{Path: res.Path, Strategy: string(res.Strategy), Origin: res.Origin, Disabled: res.Disabled}
 			}
-			return printJSON(outWriter(), items)
+			return printJSON(cmd.OutOrStdout(), items)
 		}
-
 		if len(cfg.Resources) == 0 {
-			fmt.Println("No shared resources configured.")
+			fmt.Fprintln(cmd.OutOrStdout(), "No shared resources configured.")
 			return nil
 		}
-
-		fmt.Println("Shared Resources:")
 		for _, res := range cfg.Resources {
-			fmt.Printf("  - %s (%s)\n", res.Path, res.Strategy)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s (%s; %s%s)\n", res.Path, res.Strategy, res.Origin, disabledSuffix(res.Disabled))
 		}
 		return nil
 	},
@@ -114,125 +138,172 @@ var wtShareListCmd = &cobra.Command{
 
 var wtShareDiscoverCmd = &cobra.Command{
 	Use:   "discover",
-	Short: "Discover files that should be shared across worktrees",
-	Long: `Scan the main worktree for files that should be shared across worktrees.
+	Short: "Inspect sharing and dependency hotspots",
+	Long: `Inspect nested projects, shared resources, and dependency directories across repository worktrees.
 
-By default, shows a preview of discovered files (dry-run mode).
-Use --auto to actually add discovered files and sync them.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		wtClient := newWorktreeClient()
+The preview lists directories first, largest first, with readable sizes and sharing
+status. Project manifests are summarized instead of listed as resources.
+Use --output json for full source paths, matched rules, and per-resource guidance.
 
-		results, err := wtClient.Discover(worktree.DiscoverOptions{})
-		if err != nil {
+The preview includes effective hooks, which run after sharing only during worktree
+creation. Dependency environments and build outputs are reported with guidance;
+only safe configuration-file candidates are automatically added. Size estimates
+are apparent bytes, not exclusive disk usage or guaranteed savings.
+Sources outside the primary worktree are inspected but not propagated by global
+or pattern rules.
+
+Use --auto to add candidates and sync effective rules to existing worktrees.
+Hooks are not executed by discover or share sync.`,
+	Example:           "  gmc wt share discover\n  gmc wt share discover --output json\n  gmc wt share discover --auto",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE:              runWorktreeShareDiscover,
+}
+
+func runWorktreeShareDiscover(cmd *cobra.Command, _ []string) error {
+	return discoverSharedResources(cmd, newWorktreeClient())
+}
+
+func discoverSharedResources(cmd *cobra.Command, client *worktree.Client) error {
+	if discoverAuto && cmd.Flags().Changed("dry-run") {
+		return errors.New("--auto and --dry-run are mutually exclusive")
+	}
+	results, err := client.Discover(worktree.DiscoverOptions{IncludeConfigured: true})
+	if err != nil {
+		return err
+	}
+	cfg, err := client.LoadEffectiveSharedConfig()
+	if err != nil {
+		return err
+	}
+	if outputFormat() == "json" {
+		if results == nil {
+			results = []worktree.DiscoverResult{}
+		}
+		if err := printJSON(cmd.OutOrStdout(), struct {
+			Resources []worktree.DiscoverResult `json:"resources"`
+			Hooks     []HookJSON                `json:"hooks"`
+		}{results, hookJSON(cfg.Hooks)}); err != nil {
 			return err
 		}
-
-		if len(results) == 0 {
-			fmt.Println("No new shareable files discovered.")
-			return nil
-		}
-
-		var copyResults, linkResults []worktree.DiscoverResult
-		for _, r := range results {
-			switch r.Strategy {
-			case worktree.StrategyCopy:
-				copyResults = append(copyResults, r)
-			case worktree.StrategySymlink:
-				linkResults = append(linkResults, r)
-			}
-		}
-
-		fmt.Println("Discovered shareable files:")
-		fmt.Println()
-		if len(copyResults) > 0 {
-			fmt.Println("Copy strategy (isolated per worktree):")
-			for _, r := range copyResults {
-				fmt.Printf("  %s\n", r.Path)
-			}
-		}
-		if len(linkResults) > 0 {
-			fmt.Println("Link strategy (shared, saves disk):")
-			for _, r := range linkResults {
-				fmt.Printf("  %s\n", r.Path)
-			}
-		}
-
-		if !discoverAuto {
-			fmt.Printf("\n[dry-run] Would add %d copy + %d link resources\n", len(copyResults), len(linkResults))
-			return nil
-		}
-
-		fmt.Println()
-		addReport, addErr := wtClient.AddDiscoveredResources(results)
-		printWorktreeReport(addReport)
-		if addErr != nil {
-			return addErr
-		}
-
-		fmt.Println("\nSyncing to all worktrees...")
-		report, err := wtClient.SyncAllSharedResources()
-		printWorktreeReport(report)
-		if err != nil {
-			return err
-		}
-		fmt.Println("Done.")
+	} else {
+		printDiscoverOverview(cmd, results, cfg.Hooks)
+	}
+	if !discoverAuto {
 		return nil
-	},
+	}
+	report, err := client.AddDiscoveredResources(results)
+	printPreparationReport(report)
+	if err != nil {
+		return err
+	}
+	report, err = client.SyncAllSharedResources()
+	printPreparationReport(report)
+	return err
 }
 
 var wtShareSyncCmd = &cobra.Command{
 	Use:   "sync",
-	Short: "Manually sync shared resources to all worktrees",
+	Short: "Sync effective resources to all worktrees",
+	Long: "Sync global and repository rules to existing worktrees without running hooks " +
+		"or replacing existing directories.",
+	Example:           "  gmc wt share sync",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		wtClient := newWorktreeClient()
-		report, err := wtClient.SyncAllSharedResources()
-		printWorktreeReport(report)
+		report, err := newWorktreeClient().SyncAllSharedResources()
+		printPreparationReport(report)
 		return err
 	},
 }
 
+func loadListedSharedConfig(client *worktree.Client, global bool) (*worktree.SharedConfig, error) {
+	if global {
+		cfg, _, err := client.LoadGlobalSharedConfig()
+		if err == nil {
+			for i := range cfg.Resources {
+				cfg.Resources[i].Origin = "global"
+			}
+			for i := range cfg.Hooks {
+				cfg.Hooks[i].Origin = "global"
+			}
+		}
+		return cfg, err
+	}
+	return client.LoadEffectiveSharedConfig()
+}
+
+func printPreparationReport(report worktree.Report) {
+	for _, event := range report.Events {
+		fmt.Fprintln(errWriter(), event.Message)
+	}
+}
+
+func disabledSuffix(disabled bool) string {
+	if disabled {
+		return "; disabled"
+	}
+	return ""
+}
+
+func completeSharedResources(cmd *cobra.Command, args []string, prefix string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	global, _ := cmd.Flags().GetBool("global")
+	cfg, err := loadListedSharedConfig(newWorktreeClient(), global)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var paths []string
+	for _, res := range cfg.Resources {
+		if strings.HasPrefix(res.Path, prefix) {
+			paths = append(paths, res.Path)
+		}
+	}
+	return paths, cobra.ShellCompDirectiveNoFileComp
+}
+
 func init() {
 	wtCmd.AddCommand(wtShareCmd)
-	wtShareCmd.AddCommand(wtShareAddCmd)
-	wtShareCmd.AddCommand(wtShareRemoveCmd)
-	wtShareCmd.AddCommand(wtShareListCmd)
-	wtShareCmd.AddCommand(wtShareSyncCmd)
-	wtShareCmd.AddCommand(wtShareDiscoverCmd)
-
+	wtShareCmd.AddCommand(wtShareAddCmd, wtShareRemoveCmd, wtShareListCmd, wtShareSyncCmd, wtShareDiscoverCmd)
+	for _, command := range []*cobra.Command{wtShareAddCmd, wtShareRemoveCmd, wtShareListCmd} {
+		command.Flags().Bool("global", false, "Use defaults in the selected gmc config file")
+	}
 	wtShareAddCmd.Flags().StringVarP(&shareStrategy, "strategy", "s", "copy", "Sync strategy: copy or link")
 	_ = wtShareAddCmd.RegisterFlagCompletionFunc("strategy", completeStrategies)
-
-	wtShareDiscoverCmd.Flags().BoolVar(&discoverAuto, "auto", false, "Actually add discovered items and sync")
-	wtShareDiscoverCmd.Flags().Bool("dry-run", true, "Preview mode (default behavior)")
+	wtShareDiscoverCmd.Flags().BoolVar(&discoverAuto, "auto", false, "Add safe candidates and sync effective rules")
+	wtShareDiscoverCmd.Flags().Bool("dry-run", true, "Preview only (also the default without --auto)")
+	wtShareDiscoverCmd.MarkFlagsMutuallyExclusive("auto", "dry-run")
 }
 
 func runWorktreeShareInteractive(c *worktree.Client) error {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		// Clear screen strictly speaking is not easy cross-platform without libs, just print newlines
-		fmt.Println("--- Manage Shared Resources ---")
+		fmt.Fprintln(errWriter(), "--- Manage Shared Resources ---")
 
-		cfg, _, err := c.LoadSharedConfig()
+		cfg, err := c.LoadEffectiveSharedConfig()
 		if err != nil {
 			return err
 		}
 
 		if len(cfg.Resources) > 0 {
-			fmt.Println("Current Resources:")
+			fmt.Fprintln(errWriter(), "Current Resources:")
 			for i, res := range cfg.Resources {
-				fmt.Printf("  %d. %s (%s)\n", i+1, res.Path, res.Strategy)
+				fmt.Fprintf(errWriter(), "  %d. %s (%s; %s%s)\n",
+					i+1, res.Path, res.Strategy, res.Origin, disabledSuffix(res.Disabled))
 			}
 		} else {
-			fmt.Println("No shared resources configured.")
+			fmt.Fprintln(errWriter(), "No shared resources configured.")
 		}
-		fmt.Println()
-		fmt.Println("Options:")
-		fmt.Println("  a. Add new resource")
-		fmt.Println("  r. Remove resource")
-		fmt.Println("  s. Sync all worktrees now")
-		fmt.Println("  q. Quit")
-		fmt.Print("\nSelect option: ")
+		fmt.Fprintln(errWriter())
+		fmt.Fprintln(errWriter(), "Options:")
+		fmt.Fprintln(errWriter(), "  a. Add new resource")
+		fmt.Fprintln(errWriter(), "  r. Remove resource")
+		fmt.Fprintln(errWriter(), "  s. Sync all worktrees now")
+		fmt.Fprintln(errWriter(), "  q. Quit")
+		fmt.Fprint(errWriter(), "\nSelect option: ")
 
 		input, _ := reader.ReadString('\n')
 		input = strings.TrimSpace(strings.ToLower(input))
@@ -244,17 +315,17 @@ func runWorktreeShareInteractive(c *worktree.Client) error {
 			promptRemoveResource(c, reader, cfg)
 		case "s":
 			report, err := c.SyncAllSharedResources()
-			printWorktreeReport(report)
+			printPreparationReport(report)
 			if err != nil {
-				fmt.Printf("Error syncing: %v\n", err)
+				fmt.Fprintf(errWriter(), "Error syncing: %v\n", err)
 			} else {
-				fmt.Println("Sync complete!")
+				fmt.Fprintln(errWriter(), "Sync complete!")
 			}
 			promptContinue(reader)
 		case "q":
 			return nil
 		default:
-			fmt.Println("Invalid option")
+			fmt.Fprintln(errWriter(), "Invalid option")
 		}
 	}
 }
@@ -262,7 +333,6 @@ func runWorktreeShareInteractive(c *worktree.Client) error {
 func promptAddResource(c *worktree.Client, reader *bufio.Reader) {
 	root, _ := c.GetWorktreeRoot()
 
-	// Detect current worktree
 	cwd, _ := os.Getwd()
 	currentWorktree := ""
 	if strings.HasPrefix(cwd, root) {
@@ -273,11 +343,11 @@ func promptAddResource(c *worktree.Client, reader *bufio.Reader) {
 		}
 	}
 
-	fmt.Printf("\nProject root: %s\n", root)
+	fmt.Fprintf(errWriter(), "\nProject root: %s\n", root)
 	if currentWorktree != "" {
-		fmt.Printf("Current worktree: %s\n", currentWorktree)
+		fmt.Fprintf(errWriter(), "Current worktree: %s\n", currentWorktree)
 	}
-	fmt.Print("\nPath: ")
+	fmt.Fprint(errWriter(), "\nPath: ")
 	path, _ := reader.ReadString('\n')
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -287,20 +357,19 @@ func promptAddResource(c *worktree.Client, reader *bufio.Reader) {
 	strategy := promptStrategy(reader)
 
 	report, err := c.AddSharedResource(path, strategy)
-	printWorktreeReport(report)
+	printPreparationReport(report)
 	if err != nil {
-		fmt.Printf("Error adding resource: %v\n", err)
+		fmt.Fprintf(errWriter(), "Error adding resource: %v\n", err)
 	} else {
-		fmt.Println("Resource added!")
-		// Ask to sync immediately
-		fmt.Print("Sync to all existing worktrees now? [Y/n]: ")
+		fmt.Fprintln(errWriter(), "Resource added!")
+		fmt.Fprint(errWriter(), "Sync to all existing worktrees now? [Y/n]: ")
 		syncInput, _ := reader.ReadString('\n')
 		syncInput = strings.TrimSpace(strings.ToLower(syncInput))
 		if syncInput == "" || syncInput == "y" || syncInput == "yes" {
 			report, err := c.SyncAllSharedResources()
-			printWorktreeReport(report)
+			printPreparationReport(report)
 			if err != nil {
-				fmt.Printf("Warning: failed to sync: %v\n", err)
+				fmt.Fprintf(errWriter(), "Warning: failed to sync: %v\n", err)
 			}
 		}
 	}
@@ -310,30 +379,30 @@ func promptRemoveResource(c *worktree.Client, reader *bufio.Reader, cfg *worktre
 	if len(cfg.Resources) == 0 {
 		return
 	}
-	fmt.Print("\nEnter number to remove: ")
+	fmt.Fprint(errWriter(), "\nEnter number to remove: ")
 	numStr, _ := reader.ReadString('\n')
 	var num int
 	_, err := fmt.Sscanf(strings.TrimSpace(numStr), "%d", &num)
 	if err != nil || num < 1 || num > len(cfg.Resources) {
-		fmt.Println("Invalid selection")
+		fmt.Fprintln(errWriter(), "Invalid selection")
 		return
 	}
 
 	res := cfg.Resources[num-1]
 	report, err := c.RemoveSharedResource(res.Path)
-	printWorktreeReport(report)
+	printPreparationReport(report)
 	if err != nil {
-		fmt.Printf("Error removing resource: %v\n", err)
+		fmt.Fprintf(errWriter(), "Error removing resource: %v\n", err)
 	} else {
-		fmt.Printf("Resource '%s' removed from config.\n", res.Path)
+		fmt.Fprintf(errWriter(), "Resource '%s' removed from config.\n", res.Path)
 	}
 }
 
 func promptStrategy(reader *bufio.Reader) worktree.ResourceStrategy {
-	fmt.Println("\nStrategy:")
-	fmt.Println("  1. copy - each worktree gets its own copy")
-	fmt.Println("  2. link - symlink to shared source")
-	fmt.Print("\nSelect [1/2, default: 1]: ")
+	fmt.Fprintln(errWriter(), "\nStrategy:")
+	fmt.Fprintln(errWriter(), "  1. copy - each worktree gets its own copy")
+	fmt.Fprintln(errWriter(), "  2. link - symlink to shared source")
+	fmt.Fprint(errWriter(), "\nSelect [1/2, default: 1]: ")
 	input, _ := reader.ReadString('\n')
 	input = strings.TrimSpace(strings.ToLower(input))
 	if input == "2" || input == "link" || input == "l" {
@@ -343,12 +412,12 @@ func promptStrategy(reader *bufio.Reader) worktree.ResourceStrategy {
 }
 
 func promptContinue(reader *bufio.Reader) {
-	fmt.Print("\nPress Enter to continue...")
+	fmt.Fprint(errWriter(), "\nPress Enter to continue...")
 	_, _ = reader.ReadString('\n')
 }
 
 func askToSyncAll(c *worktree.Client) error {
 	report, err := c.SyncAllSharedResources()
-	printWorktreeReport(report)
+	printPreparationReport(report)
 	return err
 }

--- a/cmd/worktree_share_display.go
+++ b/cmd/worktree_share_display.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/samzong/gmc/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+func printDiscoverOverview(cmd *cobra.Command, results []worktree.DiscoverResult, hooks []worktree.Hook) {
+	var directories, files []worktree.DiscoverResult
+	projects := make(map[string]int)
+	candidates, enabled := 0, 0
+	for _, result := range results {
+		if result.ProjectMarker {
+			label := result.Ecosystem
+			if result.PackageManager != "" && !strings.EqualFold(label, result.PackageManager) {
+				label += " (" + result.PackageManager + ")"
+			}
+			projects[label]++
+			continue
+		}
+		if result.Status == "candidate" {
+			candidates++
+		}
+		if info, err := os.Stat(result.Source); err == nil && info.IsDir() {
+			directories = append(directories, result)
+		} else {
+			files = append(files, result)
+		}
+	}
+	out := cmd.OutOrStdout()
+	if len(results) == 0 {
+		fmt.Fprintln(out, "No shared resources or supported projects found.")
+	}
+	printDiscoverTable(cmd, "Directories", directories)
+	printDiscoverTable(cmd, "Files and unresolved paths", files)
+	if len(projects) > 0 {
+		labels := make([]string, 0, len(projects))
+		for label, count := range projects {
+			labels = append(labels, fmt.Sprintf("%s: %d", label, count))
+		}
+		sort.Strings(labels)
+		fmt.Fprintf(out, "Projects: %s\n", strings.Join(labels, "; "))
+	}
+	if len(directories)+len(files) > 0 {
+		fmt.Fprintln(out, "Sizes are logical bytes, not disk savings; + means a partial scan.")
+		fmt.Fprintln(out, "Sharing = configured strategy; Current = state in this worktree.")
+	}
+	for _, result := range results {
+		if result.ProjectMarker {
+			continue
+		}
+		if (result.Status == "configured" && strings.Contains(result.Reason, ";")) ||
+			result.Source == "" || result.TargetState == "broken-link" || result.TargetState == "unreadable" ||
+			result.TargetState == "other-link" {
+			fmt.Fprintf(out, "Note: %s — %s\n", result.Path, result.Reason)
+			if result.Source != "" {
+				fmt.Fprintf(out, "  Source: %s\n", result.Source)
+			}
+		}
+	}
+	for _, hook := range hooks {
+		if !hook.Disabled {
+			enabled++
+		}
+	}
+	if len(hooks) > 0 {
+		fmt.Fprintf(out, "\nHooks: %d enabled, %d disabled (creation only, after sharing).\n", enabled, len(hooks)-enabled)
+		fmt.Fprintln(out, "  Inspect commands: gmc wt hook list")
+	} else {
+		fmt.Fprintln(out, "\nHooks: none configured.")
+	}
+	if candidates > 0 && !discoverAuto {
+		fmt.Fprintf(out, "\nApply %d copy candidates and sync rules: gmc wt share discover --auto\n", candidates)
+	} else {
+		fmt.Fprintln(out, "\nRules: gmc wt share list\nSync:  gmc wt share sync")
+	}
+	fmt.Fprintln(out, "Full details: gmc wt share discover --output json")
+}
+
+func printDiscoverTable(cmd *cobra.Command, title string, results []worktree.DiscoverResult) {
+	if len(results) == 0 {
+		return
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].SizeBytes == results[j].SizeBytes {
+			return results[i].Path < results[j].Path
+		}
+		return results[i].SizeBytes > results[j].SizeBytes
+	})
+	fmt.Fprintf(cmd.OutOrStdout(), "%s (%d)\n", title, len(results))
+	table := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(table, "SIZE\tSHARING\tCURRENT\tPATH")
+	for _, result := range results {
+		sharing := string(result.Strategy)
+		switch result.Status {
+		case "candidate":
+			sharing = "copy available"
+		case "managed":
+			sharing = "not configured"
+		case "excluded":
+			sharing = "disabled"
+		case "tracked":
+			sharing = "Git-tracked"
+		}
+		current := strings.ReplaceAll(result.TargetState, "-", " ")
+		if current == "" {
+			current = "unknown"
+		}
+		fmt.Fprintf(table, "%s\t%s\t%s\t%s\n", discoverSize(result), sharing, current, result.Path)
+	}
+	_ = table.Flush()
+	fmt.Fprintln(cmd.OutOrStdout())
+}
+
+func discoverSize(result worktree.DiscoverResult) string {
+	if result.Source == "" {
+		return "unknown"
+	}
+	size := float64(result.SizeBytes)
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+	unit := 0
+	for size >= 1024 && unit < len(units)-1 {
+		size /= 1024
+		unit++
+	}
+	var text string
+	if unit == 0 {
+		text = fmt.Sprintf("%d B", result.SizeBytes)
+	} else {
+		text = fmt.Sprintf("%.1f %s", size, units[unit])
+	}
+	if result.SizeLimited {
+		text += "+"
+	}
+	return text
+}

--- a/cmd/worktree_share_test.go
+++ b/cmd/worktree_share_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samzong/gmc/internal/worktree"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverRejectsExplicitDryRunWithAutoBeforeLoadingConfig(t *testing.T) {
+	previousAuto := discoverAuto
+	t.Cleanup(func() { discoverAuto = previousAuto })
+	discoverAuto = true
+	for _, value := range []string{"true", "false"} {
+		t.Run(value, func(t *testing.T) {
+			command := &cobra.Command{Use: "discover"}
+			command.Flags().Bool("dry-run", true, "")
+			require.NoError(t, command.Flags().Set("dry-run", value))
+			err := discoverSharedResources(command, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDiscoverPreviewDoesNotConfigureOrRunHooks(t *testing.T) {
+	repo := initCmdTestRepo(t)
+	t.Chdir(repo)
+	globalPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(globalPath, []byte("worktree: {}\n"), 0o600))
+	configPath := filepath.Join(repo, ".git", "gmc-share.yml")
+	originalConfig := []byte("hooks:\n  - id: install\n    cmd: touch hook-ran\n")
+	require.NoError(t, os.WriteFile(configPath, originalConfig, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".env"), []byte("EXAMPLE=1\n"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "apps", "web", "node_modules"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "apps", "web", "package.json"), []byte("{}"), 0o600))
+
+	previousAuto, previousOutput := discoverAuto, outputFlag.value
+	t.Cleanup(func() {
+		discoverAuto = previousAuto
+		outputFlag.value = previousOutput
+	})
+	discoverAuto = false
+	outputFlag.value = "json"
+	command := &cobra.Command{Use: "discover"}
+	command.Flags().Bool("dry-run", true, "")
+	require.NoError(t, command.Flags().Set("dry-run", "false"))
+	var output bytes.Buffer
+	command.SetOut(&output)
+	client := worktree.NewClient(worktree.Options{GlobalConfigPath: globalPath})
+	require.NoError(t, discoverSharedResources(command, client))
+
+	var preview struct {
+		Resources []worktree.DiscoverResult `json:"resources"`
+		Hooks     []HookJSON                `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(output.Bytes(), &preview))
+	require.Len(t, preview.Hooks, 1)
+	assert.Equal(t, "install", preview.Hooks[0].ID)
+	var foundNested bool
+	for _, resource := range preview.Resources {
+		if resource.Path == "apps/web/node_modules" {
+			foundNested = true
+			assert.NotEqual(t, "candidate", resource.Status)
+		}
+	}
+	assert.True(t, foundNested)
+	output.Reset()
+	outputFlag.value = "text"
+	require.NoError(t, discoverSharedResources(command, client))
+	text := output.String()
+	directoryPosition := strings.Index(text, "apps/web/node_modules")
+	filePosition := strings.Index(text, ".env")
+	require.GreaterOrEqual(t, directoryPosition, 0)
+	require.Greater(t, filePosition, directoryPosition)
+	assert.Contains(t, text, "Node.js (npm): 1")
+	assert.NotContains(t, text, "package.json")
+	assert.NotContains(t, text, "touch hook-ran")
+	actualConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalConfig, actualConfig)
+	_, err = os.Stat(filepath.Join(repo, "hook-ran"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestHookListIndicesMatchEffectiveRemoval(t *testing.T) {
+	repo := initCmdTestRepo(t)
+	t.Chdir(repo)
+	globalPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(globalPath,
+		[]byte("worktree:\n  hooks:\n    - id: install\n      cmd: echo install\n"+
+			"    - id: setup\n      cmd: echo setup\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git", "gmc-share.yml"),
+		[]byte("hooks:\n  - id: install\n    disabled: true\n"), 0o600))
+	client := worktree.NewClient(worktree.Options{GlobalConfigPath: globalPath})
+	previousOutput := outputFlag.value
+	t.Cleanup(func() { outputFlag.value = previousOutput })
+	outputFlag.value = "json"
+	command := &cobra.Command{Use: "list"}
+	command.Flags().Bool("global", false, "")
+	var output bytes.Buffer
+	command.SetOut(&output)
+	require.NoError(t, runHookListCommand(command, client))
+	var hooks []HookJSON
+	require.NoError(t, json.Unmarshal(output.Bytes(), &hooks))
+	require.Len(t, hooks, 2)
+	assert.True(t, hooks[0].Disabled)
+	assert.Equal(t, "setup", hooks[1].ID)
+	_, err := client.RemoveHook(hooks[1].Index - 1)
+	require.NoError(t, err)
+	cfg, err := client.LoadEffectiveSharedConfig()
+	require.NoError(t, err)
+	require.Len(t, cfg.Hooks, 2)
+	assert.True(t, cfg.Hooks[1].Disabled)
+	global, _, err := client.LoadGlobalSharedConfig()
+	require.NoError(t, err)
+	assert.False(t, global.Hooks[1].Disabled)
+
+	output.Reset()
+	require.NoError(t, command.Flags().Set("global", "true"))
+	require.NoError(t, runHookListCommand(command, client))
+	require.NoError(t, json.Unmarshal(output.Bytes(), &hooks))
+	require.Len(t, hooks, 2)
+	assert.Equal(t, "global", hooks[0].Origin)
+	assert.False(t, hooks[0].Disabled)
+	assert.False(t, hooks[1].Disabled)
+}

--- a/cmd/worktree_test.go
+++ b/cmd/worktree_test.go
@@ -48,7 +48,7 @@ func TestRunWorktreeDefault_ShowsWorktreesInNonBareRepo(t *testing.T) {
 	assert.NotContains(t, output, "not using the bare worktree pattern")
 }
 
-func TestWtHookRemoveCmd_RejectsTrailingCharactersInIndex(t *testing.T) {
+func TestWtHookRemoveCmd_UnknownIDPreservesHooks(t *testing.T) {
 	repoDir := initCmdTestRepo(t)
 	cfgPath := filepath.Join(repoDir, ".git", "gmc-share.yml")
 	require.NoError(t, os.WriteFile(cfgPath, []byte("hooks:\n  - cmd: echo ok\n"), 0o644))
@@ -70,7 +70,6 @@ func TestWtHookRemoveCmd_RejectsTrailingCharactersInIndex(t *testing.T) {
 
 	err = wtHookRemoveCmd.RunE(wtHookRemoveCmd, []string{"1abc"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid hook index")
 
 	client := worktree.NewClient(worktree.Options{})
 	cfg, _, err := client.LoadSharedConfig()

--- a/docs/man/gmc-wt-hook-add.1
+++ b/docs/man/gmc-wt-hook-add.1
@@ -2,7 +2,7 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-hook-add - Add a hook to run after worktree creation
+gmc-wt-hook-add - Add or replace a worktree hook
 
 
 .SH SYNOPSIS
@@ -10,16 +10,12 @@ gmc-wt-hook-add - Add a hook to run after worktree creation
 
 
 .SH DESCRIPTION
-Add a hook command that will be executed after shared resources are synced to a worktree.
+Configure a command executed after sharing during worktree creation.
 
 .PP
-Hooks are executed in the target worktree directory after resources are synced.
-This is useful for running package installation commands like 'pnpm install'.
-
-.PP
-Example:
-  gmc wt hook add "pnpm install" -d "Install dependencies"
-  gmc wt hook add "pnpm install && pnpm build"
+A repository hook with the same ID replaces an inherited global hook. Global
+commands run in every repository; use shell conditions for project-specific work.
+Adding a hook does not execute it.
 
 
 .SH OPTIONS
@@ -29,6 +25,10 @@ Example:
 .PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for add
+
+.PP
+\fB--id\fP=""
+	Stable hook ID for repository overrides and removal
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -40,8 +40,19 @@ Example:
 	Enable debug output
 
 .PP
+\fB--global\fP[=false]
+	Use defaults in the selected gmc config file
+
+.PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt hook add 'pnpm install' --id install --desc 'Install dependencies'
+  gmc wt hook add 'test ! -f uv.lock || uv sync' --id python --global
+.EE
 
 
 .SH SEE ALSO

--- a/docs/man/gmc-wt-hook-list.1
+++ b/docs/man/gmc-wt-hook-list.1
@@ -2,22 +2,18 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-share-list - List effective shared resources
+gmc-wt-hook-list - List effective hooks in execution order
 
 
 .SH SYNOPSIS
-\fBgmc wt share list [flags]\fP
+\fBgmc wt hook list [flags]\fP
 
 
 .SH DESCRIPTION
-List effective shared resources
+List effective hooks in execution order
 
 
 .SH OPTIONS
-\fB--global\fP[=false]
-	Use defaults in the selected gmc config file
-
-.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for list
 
@@ -31,12 +27,16 @@ List effective shared resources
 	Enable debug output
 
 .PP
+\fB--global\fP[=false]
+	Use defaults in the selected gmc config file
+
+.PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
 
 
 .SH SEE ALSO
-\fBgmc-wt-share(1)\fP
+\fBgmc-wt-hook(1)\fP
 
 
 .SH HISTORY

--- a/docs/man/gmc-wt-hook-remove.1
+++ b/docs/man/gmc-wt-hook-remove.1
@@ -2,7 +2,7 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-hook-remove - Remove a hook by index
+gmc-wt-hook-remove - Remove or disable a hook
 
 
 .SH SYNOPSIS
@@ -10,7 +10,11 @@ gmc-wt-hook-remove - Remove a hook by index
 
 
 .SH DESCRIPTION
-Remove a hook by index
+Remove a hook by its ID or the one-based index shown by hook list.
+
+.PP
+Repository removal also disables an inherited global hook. With --global, use
+the index from hook list --global to remove a global default.
 
 
 .SH OPTIONS
@@ -27,8 +31,19 @@ Remove a hook by index
 	Enable debug output
 
 .PP
+\fB--global\fP[=false]
+	Use defaults in the selected gmc config file
+
+.PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt hook remove install
+  gmc wt hook remove 1 --global
+.EE
 
 
 .SH SEE ALSO

--- a/docs/man/gmc-wt-hook.1
+++ b/docs/man/gmc-wt-hook.1
@@ -2,7 +2,7 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-hook - Manage hooks executed after worktree creation
+gmc-wt-hook - Manage hooks after worktree creation
 
 
 .SH SYNOPSIS
@@ -10,18 +10,19 @@ gmc-wt-hook - Manage hooks executed after worktree creation
 
 
 .SH DESCRIPTION
-Manage hooks that are executed after shared resources are synced to a new worktree.
+Manage commands run in a new worktree after shared resources are prepared.
 
 .PP
-Hooks run in the target worktree directory and are useful for running
-package installation commands like 'pnpm install'.
-
-.PP
-Config file is stored at the repository's shared git common dir
-(for example .git/gmc-share.yml or .bare/gmc-share.yml).
+Global defaults live under worktree.hooks in the selected gmc config file.
+Repository hooks live alongside shared resources in gmc-share.yml. Give a hook an
+ID to replace or disable it in a repository. Hooks run in effective list order.
 
 
 .SH OPTIONS
+\fB--global\fP[=false]
+	Use defaults in the selected gmc config file
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for hook
 
@@ -40,7 +41,7 @@ Config file is stored at the repository's shared git common dir
 
 
 .SH SEE ALSO
-\fBgmc-wt(1)\fP, \fBgmc-wt-hook-add(1)\fP, \fBgmc-wt-hook-remove(1)\fP
+\fBgmc-wt(1)\fP, \fBgmc-wt-hook-add(1)\fP, \fBgmc-wt-hook-list(1)\fP, \fBgmc-wt-hook-remove(1)\fP
 
 
 .SH HISTORY

--- a/docs/man/gmc-wt-share-add.1
+++ b/docs/man/gmc-wt-share-add.1
@@ -10,15 +10,26 @@ gmc-wt-share-add - Add or update a shared resource
 
 
 .SH DESCRIPTION
-Add a file or directory to be shared across all worktrees.
+Add a file or directory shared across worktrees in each repository.
 
 .PP
-Strategies:
-  - copy: Copies the file/directory (good for .env files that need isolation)
-  - link: Creates a symlink (good for large model directories)
+copy creates an independent copy; link shares a writable source through a symlink.
+Global defaults apply when creating worktrees. Adding a global rule does not sync
+existing worktrees. Run share sync in a repository to apply its effective rules.
+Global and pattern rules use the primary worktree as their source, never a
+directory found only in another linked worktree.
+
+.PP
+Quote patterns such as '**/.local' to match nested project paths. Pattern scans
+skip dependency, build, and .local directory interiors. Linking dependency environments
+shares writable state across branches; prefer package-manager caches where possible.
 
 
 .SH OPTIONS
+\fB--global\fP[=false]
+	Use defaults in the selected gmc config file
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for add
 
@@ -38,6 +49,14 @@ Strategies:
 .PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt share add .env --strategy copy
+  gmc wt share add .local --strategy link --global
+  gmc wt share add '**/node_modules' --strategy link --global
+.EE
 
 
 .SH SEE ALSO

--- a/docs/man/gmc-wt-share-discover.1
+++ b/docs/man/gmc-wt-share-discover.1
@@ -2,7 +2,7 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-share-discover - Discover files that should be shared across worktrees
+gmc-wt-share-discover - Inspect sharing and dependency hotspots
 
 
 .SH SYNOPSIS
@@ -10,20 +10,33 @@ gmc-wt-share-discover - Discover files that should be shared across worktrees
 
 
 .SH DESCRIPTION
-Scan the main worktree for files that should be shared across worktrees.
+Inspect nested projects, shared resources, and dependency directories across repository worktrees.
 
 .PP
-By default, shows a preview of discovered files (dry-run mode).
-Use --auto to actually add discovered files and sync them.
+The preview lists directories first, largest first, with readable sizes and sharing
+status. Project manifests are summarized instead of listed as resources.
+Use --output json for full source paths, matched rules, and per-resource guidance.
+
+.PP
+The preview includes effective hooks, which run after sharing only during worktree
+creation. Dependency environments and build outputs are reported with guidance;
+only safe configuration-file candidates are automatically added. Size estimates
+are apparent bytes, not exclusive disk usage or guaranteed savings.
+Sources outside the primary worktree are inspected but not propagated by global
+or pattern rules.
+
+.PP
+Use --auto to add candidates and sync effective rules to existing worktrees.
+Hooks are not executed by discover or share sync.
 
 
 .SH OPTIONS
 \fB--auto\fP[=false]
-	Actually add discovered items and sync
+	Add safe candidates and sync effective rules
 
 .PP
 \fB--dry-run\fP[=true]
-	Preview mode (default behavior)
+	Preview only (also the default without --auto)
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]
@@ -41,6 +54,14 @@ Use --auto to actually add discovered files and sync them.
 .PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt share discover
+  gmc wt share discover --output json
+  gmc wt share discover --auto
+.EE
 
 
 .SH SEE ALSO

--- a/docs/man/gmc-wt-share-remove.1
+++ b/docs/man/gmc-wt-share-remove.1
@@ -2,7 +2,7 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-share-remove - Remove a shared resource from config
+gmc-wt-share-remove - Remove or disable a shared resource
 
 
 .SH SYNOPSIS
@@ -10,10 +10,15 @@ gmc-wt-share-remove - Remove a shared resource from config
 
 
 .SH DESCRIPTION
-Remove a shared resource from config
+Remove a repository rule and disable any inherited global rule for that path.
+Use --global to remove a global default. Existing files are preserved.
 
 
 .SH OPTIONS
+\fB--global\fP[=false]
+	Use defaults in the selected gmc config file
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for remove
 
@@ -29,6 +34,13 @@ Remove a shared resource from config
 .PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt share remove .local
+  gmc wt share remove .local --global
+.EE
 
 
 .SH SEE ALSO

--- a/docs/man/gmc-wt-share-sync.1
+++ b/docs/man/gmc-wt-share-sync.1
@@ -2,7 +2,7 @@
 .TH "GMC" "1" "Jun 2026" "gmc" "GMC Manual"
 
 .SH NAME
-gmc-wt-share-sync - Manually sync shared resources to all worktrees
+gmc-wt-share-sync - Sync effective resources to all worktrees
 
 
 .SH SYNOPSIS
@@ -10,7 +10,7 @@ gmc-wt-share-sync - Manually sync shared resources to all worktrees
 
 
 .SH DESCRIPTION
-Manually sync shared resources to all worktrees
+Sync global and repository rules to existing worktrees without running hooks or replacing existing directories.
 
 
 .SH OPTIONS
@@ -29,6 +29,12 @@ Manually sync shared resources to all worktrees
 .PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt share sync
+.EE
 
 
 .SH SEE ALSO

--- a/docs/man/gmc-wt-share.1
+++ b/docs/man/gmc-wt-share.1
@@ -10,14 +10,12 @@ gmc-wt-share - Manage shared resources for worktrees
 
 
 .SH DESCRIPTION
-Manage shared resources that are automatically synced to all worktrees.
+Manage resources prepared before hooks run in new worktrees.
 
 .PP
-If run without arguments, it opens an interactive mode to manage resources.
-
-.PP
-Config file is stored at the repository's shared git common dir
-(for example .git/gmc-share.yml or .bare/gmc-share.yml).
+Global defaults live under worktree in the selected gmc config file.
+Repository rules in the git common dir's gmc-share.yml override global paths.
+Run without arguments for interactive repository management.
 
 
 .SH OPTIONS
@@ -36,6 +34,13 @@ Config file is stored at the repository's shared git common dir
 .PP
 \fB-o\fP, \fB--output\fP="text"
 	Output format: text or json
+
+
+.SH EXAMPLE
+.EX
+  gmc wt share discover
+  gmc wt share list --global
+.EE
 
 
 .SH SEE ALSO

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,10 @@ const (
 
 var configFilePath string
 
+func FilePath() string {
+	return configFilePath
+}
+
 var suggestedRoles = []string{
 	"Developer",
 	"Frontend Developer",

--- a/internal/worktree/project_scan.go
+++ b/internal/worktree/project_scan.go
@@ -1,0 +1,305 @@
+package worktree
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func scanShareProjects(root string, rules []SharedResource) ([]DiscoverResult, []DiscoverResult, error) {
+	var resources []DiscoverResult
+	var buildDirectories []string
+	manifests := make(map[string]map[string]bool)
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		name := entry.Name()
+		if name == ".git" || name == ".bare" {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			if _, err := os.Lstat(filepath.Join(path, ".git")); err == nil {
+				return filepath.SkipDir
+			}
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if shareRuleMatches(rules, rel) {
+				resources = append(resources, DiscoverResult{Path: rel})
+			}
+			return nil
+		}
+		var candidate DiscoverResult
+		candidate.Path = rel
+		for _, suffix := range copyCandidates {
+			if rel == suffix || strings.HasSuffix(rel, "/"+suffix) {
+				candidate.Strategy, candidate.Reason = StrategyCopy, "config/env file; isolated copy per worktree"
+			}
+		}
+		if entry.IsDir() {
+			for _, suffix := range managedDirectories {
+				if name == suffix {
+					candidate.Status = "managed"
+					candidate.Reason = "mutable dependency/cache directory; keep independent across worktrees; " +
+						"use package-manager caches for reuse or configure an explicit share rule"
+				}
+			}
+		}
+		if _, covered := discoverCoveringRule(rules, rel); covered {
+			if candidate.Strategy != "" || candidate.Status != "" || shareRuleMatches(rules, rel) {
+				resources = append(resources, candidate)
+			}
+		} else if candidate.Strategy != "" || candidate.Status != "" {
+			resources = append(resources, candidate)
+		}
+		if entry.IsDir() {
+			if name == "target" && !shareRuleMatches(rules, rel) {
+				buildDirectories = append(buildDirectories, rel)
+			}
+			switch name {
+			case "node_modules", ".venv", "venv", "vendor", "__pycache__", "target", "build", "dist", ".next", ".nuxt",
+				".local", ".cache", ".turbo", ".tox", ".mypy_cache", ".pytest_cache":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		switch name {
+		case "package.json", "pnpm-lock.yaml", "yarn.lock", "package-lock.json", "bun.lock", "bun.lockb",
+			"pyproject.toml", "uv.lock", "requirements.txt", "Pipfile", "Pipfile.lock", "poetry.lock",
+			"go.mod", "go.work", "Cargo.toml", "Cargo.lock":
+			dir := filepath.ToSlash(filepath.Dir(rel))
+			if manifests[dir] == nil {
+				manifests[dir] = make(map[string]bool)
+			}
+			manifests[dir][name] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	seen := make(map[string]bool)
+	for _, resource := range resources {
+		seen[resource.Path] = true
+	}
+	for _, rule := range rules {
+		if seen[rule.Path] || strings.ContainsAny(rule.Path, "*?[") {
+			continue
+		}
+		if err := ensureSharedDestination(root, rule.Path); err != nil {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(root, rule.Path, ".git")); err == nil {
+			continue
+		}
+		insideRepository := false
+		for parent := filepath.Dir(rule.Path); parent != "."; parent = filepath.Dir(parent) {
+			if _, err := os.Lstat(filepath.Join(root, parent, ".git")); err == nil {
+				insideRepository = true
+				break
+			}
+		}
+		if !insideRepository {
+			if _, err := os.Lstat(filepath.Join(root, rule.Path)); err == nil {
+				resources = append(resources, DiscoverResult{Path: rule.Path})
+			}
+		}
+	}
+	var projects []DiscoverResult
+	for dir, files := range manifests {
+		for _, project := range identifyShareProjects(files) {
+			project.Project = dir
+			project.Path = filepath.ToSlash(filepath.Join(dir, project.Path))
+			project.Status = "managed"
+			projects = append(projects, project)
+		}
+	}
+	sort.Slice(projects, func(i, j int) bool { return projects[i].Path < projects[j].Path })
+	for i, project := range projects {
+		if project.Ecosystem != "Node.js" || filepath.Base(project.Path) != "package.json" {
+			continue
+		}
+		var inherited DiscoverResult
+		for _, parent := range projects {
+			if parent.Ecosystem != "Node.js" || filepath.Base(parent.Path) == "package.json" {
+				continue
+			}
+			if parent.Project == "." || strings.HasPrefix(project.Project, parent.Project+"/") {
+				if len(parent.Project) > len(inherited.Project) {
+					inherited = parent
+				}
+			}
+		}
+		if inherited.Project != "" {
+			projects[i].PackageManager = inherited.PackageManager
+			projects[i].Reason = inherited.Reason
+		}
+	}
+	for _, path := range buildDirectories {
+		if project, found := nearestShareProject(path, projects); found && project.Ecosystem == "Rust" {
+			resources = append(resources, DiscoverResult{
+				Path: path, Status: "managed",
+				Reason: "Cargo build artifacts; keep target isolated instead of sharing a writable directory across branches",
+			})
+		}
+	}
+	return resources, projects, nil
+}
+
+func shareRuleMatches(rules []SharedResource, path string) bool {
+	for _, rule := range rules {
+		if MatchSharedPath(rule.Path, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func identifyShareProjects(files map[string]bool) []DiscoverResult {
+	var projects []DiscoverResult
+	if files["package.json"] || files["pnpm-lock.yaml"] || files["yarn.lock"] ||
+		files["package-lock.json"] || files["bun.lock"] || files["bun.lockb"] {
+		p := DiscoverResult{
+			Path: "package.json", Ecosystem: "Node.js", PackageManager: "npm",
+			Reason: "package-manager caches can reuse downloaded packages; " +
+				"keep node_modules independent across differing dependency graphs",
+		}
+		for _, choice := range []struct{ file, manager string }{
+			{"package-lock.json", "npm"}, {"yarn.lock", "yarn"}, {"bun.lockb", "bun"},
+			{"bun.lock", "bun"}, {"pnpm-lock.yaml", "pnpm"},
+		} {
+			if files[choice.file] {
+				p.Path, p.PackageManager = choice.file, choice.manager
+			}
+		}
+		if p.PackageManager == "pnpm" {
+			p.Reason = "pnpm's content-addressable store can reuse package files; " +
+				"directory sizes are not exclusive disk usage; keep branch dependency graphs independent"
+		}
+		projects = append(projects, p)
+	}
+	if files["pyproject.toml"] || files["uv.lock"] || files["requirements.txt"] ||
+		files["Pipfile"] || files["poetry.lock"] || files["Pipfile.lock"] {
+		p := DiscoverResult{
+			Ecosystem: "Python", PackageManager: "pip",
+			Reason: "package-manager caches reuse downloads and wheels; " +
+				"virtual environments may embed absolute paths and should remain worktree-local",
+		}
+		for _, choice := range []struct{ file, manager string }{
+			{"requirements.txt", "pip"}, {"pyproject.toml", "pip"}, {"Pipfile", "pipenv"},
+			{"Pipfile.lock", "pipenv"}, {"poetry.lock", "poetry"}, {"uv.lock", "uv"},
+		} {
+			if files[choice.file] {
+				p.Path, p.PackageManager = choice.file, choice.manager
+			}
+		}
+		if p.PackageManager == "uv" {
+			p.Reason = "uv's shared cache can reuse package files; " +
+				"keep .venv local because environments can embed absolute paths"
+		}
+		projects = append(projects, p)
+	}
+	if files["go.mod"] || files["go.work"] {
+		file := "go.mod"
+		if files["go.work"] {
+			file = "go.work"
+		}
+		projects = append(projects, DiscoverResult{
+			Path: file, Ecosystem: "Go", PackageManager: "go",
+			Reason: "Go already uses GOMODCACHE and GOCACHE outside the worktree by default; " +
+				"inspect custom cache settings before adding share rules",
+		})
+	}
+	if files["Cargo.toml"] || files["Cargo.lock"] {
+		file := "Cargo.toml"
+		if !files[file] {
+			file = "Cargo.lock"
+		}
+		projects = append(projects, DiscoverResult{
+			Path: file, Ecosystem: "Rust", PackageManager: "cargo",
+			Reason: "Cargo reuses registry and Git downloads through CARGO_HOME; " +
+				"target contains mutable build artifacts and is not recommended for blanket linking",
+		})
+	}
+	return projects
+}
+
+func nearestShareProject(path string, projects []DiscoverResult) (DiscoverResult, bool) {
+	wanted := ""
+	switch filepath.Base(path) {
+	case "node_modules":
+		wanted = "Node.js"
+	case ".venv", "venv", "__pycache__":
+		wanted = "Python"
+	case "target":
+		wanted = "Rust"
+	}
+	var nearest DiscoverResult
+	found := false
+	for _, project := range projects {
+		if wanted != "" && wanted != project.Ecosystem {
+			continue
+		}
+		if project.Project == "." || strings.HasPrefix(path, project.Project+"/") {
+			if !found || len(project.Project) > len(nearest.Project) {
+				nearest, found = project, true
+			}
+		}
+	}
+	return nearest, found
+}
+
+func discoverLogicalSize(root string) (int64, bool) {
+	var size int64
+	limited := false
+	count := 0
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			limited = true
+			return fs.SkipAll
+		}
+		count++
+		if count > 20000 {
+			limited = true
+			return fs.SkipAll
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" || entry.Name() == ".bare" {
+				return filepath.SkipDir
+			}
+			if path != root {
+				if _, err := os.Lstat(filepath.Join(path, ".git")); err == nil {
+					limited = true
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			limited = true
+			return fs.SkipAll
+		}
+		if info.Mode().IsRegular() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, limited || err != nil
+}

--- a/internal/worktree/resource.go
+++ b/internal/worktree/resource.go
@@ -20,13 +20,19 @@ const (
 )
 
 type SharedResource struct {
-	Path     string           `yaml:"path"`
-	Strategy ResourceStrategy `yaml:"strategy"`
+	worktreeRelative bool
+	Path             string           `yaml:"path" json:"path"`
+	Strategy         ResourceStrategy `yaml:"strategy,omitempty" json:"strategy,omitempty"`
+	Disabled         bool             `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	Origin           string           `yaml:"-" json:"origin,omitempty"`
 }
 
 type Hook struct {
-	Cmd  string `yaml:"cmd"`
-	Desc string `yaml:"desc,omitempty"`
+	ID       string `yaml:"id,omitempty" json:"id,omitempty"`
+	Cmd      string `yaml:"cmd,omitempty" json:"cmd,omitempty"`
+	Desc     string `yaml:"desc,omitempty" json:"desc,omitempty"`
+	Disabled bool   `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	Origin   string `yaml:"-" json:"origin,omitempty"`
 }
 
 const (
@@ -54,7 +60,7 @@ func (c *Client) SyncSharedResources(worktreeName string) (Report, error) {
 func (c *Client) syncSharedResourcesToPath(targetRoot string, runHooks bool) (Report, error) {
 	var report Report
 
-	cfg, _, err := c.LoadSharedConfig()
+	cfg, err := c.LoadEffectiveSharedConfig()
 	if err != nil {
 		return report, err
 	}
@@ -67,7 +73,11 @@ func (c *Client) syncSharedResourcesToPath(targetRoot string, runHooks bool) (Re
 		return report, err
 	}
 
-	for _, res := range cfg.Resources {
+	resources, err := c.expandSharedResources(cfg.Resources)
+	if err != nil {
+		return report, err
+	}
+	for _, res := range resources {
 		resourceReport, err := c.syncOneResource(c.worktreeRoot, targetRoot, res)
 		report.Merge(resourceReport)
 		if err != nil {
@@ -111,9 +121,38 @@ func (c *Client) syncOneResource(repoRoot, targetRoot string, res SharedResource
 		}
 		return report, nil
 	}
+	if err != nil {
+		return report, fmt.Errorf("cannot inspect shared source %s: %w", srcPath, err)
+	}
 
-	if _, err := os.Stat(dstPath); err == nil {
+	if filepath.Clean(srcPath) == filepath.Clean(dstPath) {
 		return report, nil
+	}
+	if dstInfo, statErr := os.Lstat(dstPath); statErr == nil {
+		if res.Strategy == StrategyCopy && dstInfo.Mode().Type() == info.Mode().Type() {
+			return report, nil
+		}
+		if dstInfo.Mode()&os.ModeSymlink != 0 {
+			destination, dstErr := filepath.EvalSymlinks(dstPath)
+			source, srcErr := filepath.EvalSymlinks(srcPath)
+			if dstErr == nil && srcErr == nil && destination == source && res.Strategy == StrategySymlink {
+				return report, nil
+			}
+		}
+		report.Warn(fmt.Sprintf("Kept existing resource: %s (not replaced; requested %s from %s)",
+			dstPath, res.Strategy, srcPath))
+		return report, nil
+	} else if !os.IsNotExist(statErr) {
+		return report, fmt.Errorf("cannot inspect shared destination %s: %w", dstPath, statErr)
+	}
+	if err := ensureUntrackedResource(targetRoot, targetPath); err != nil {
+		return report, err
+	}
+	if err := ensureUntrackedResource(filepath.Dir(srcPath), filepath.Base(srcPath)); err != nil {
+		return report, err
+	}
+	if err := ensureSharedDestination(targetRoot, targetPath); err != nil {
+		return report, err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
@@ -198,6 +237,9 @@ func (c *Client) LoadSharedConfig() (*SharedConfig, string, error) {
 }
 
 func (c *Client) SaveSharedConfig(cfg *SharedConfig, path string) error {
+	if err := validateSharedConfig(cfg); err != nil {
+		return err
+	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal shared config: %w", err)
@@ -207,133 +249,26 @@ func (c *Client) SaveSharedConfig(cfg *SharedConfig, path string) error {
 		return fmt.Errorf("failed to create shared config directory: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := writeSharedConfig(path, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write shared config: %w", err)
 	}
 	return nil
 }
 
 func (c *Client) AddSharedResource(path string, strategy ResourceStrategy) (Report, error) {
-	var report Report
-
-	normalizedPath, err := c.NormalizeSharedResourcePath(path)
-	if err != nil {
-		return report, err
-	}
-
-	cfg, configPath, err := c.LoadSharedConfig()
-	if err != nil {
-		return report, err
-	}
-
-	found := false
-	for i, res := range cfg.Resources {
-		if res.Path == normalizedPath {
-			cfg.Resources[i].Strategy = strategy
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		cfg.Resources = append(cfg.Resources, SharedResource{
-			Path:     normalizedPath,
-			Strategy: strategy,
-		})
-	}
-
-	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
-		return report, err
-	}
-
-	report.Info(fmt.Sprintf("Updated shared resource: %s (%s)", normalizedPath, strategy))
-	return report, nil
+	return c.addSharedResource(path, strategy, false)
 }
 
 func (c *Client) RemoveSharedResource(path string) (Report, error) {
-	var report Report
-
-	normalizedPath, err := c.NormalizeSharedResourcePath(path)
-	if err != nil {
-		return report, err
-	}
-
-	cfg, configPath, err := c.LoadSharedConfig()
-	if err != nil {
-		return report, err
-	}
-
-	var newResources []SharedResource
-	for _, res := range cfg.Resources {
-		if res.Path != normalizedPath {
-			newResources = append(newResources, res)
-		}
-	}
-
-	if len(newResources) == len(cfg.Resources) {
-		return report, fmt.Errorf("resource not found in config: %s", normalizedPath)
-	}
-
-	cfg.Resources = newResources
-	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
-		return report, err
-	}
-
-	report.Info("Removed shared resource: " + normalizedPath)
-	return report, nil
+	return c.removeSharedResource(path, false)
 }
 
 func (c *Client) AddHook(hook Hook) (Report, error) {
-	var report Report
-
-	if hook.Cmd == "" {
-		return report, errors.New("hook command cannot be empty")
-	}
-
-	cfg, configPath, err := c.LoadSharedConfig()
-	if err != nil {
-		return report, err
-	}
-
-	cfg.Hooks = append(cfg.Hooks, hook)
-
-	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
-		return report, err
-	}
-
-	desc := hook.Desc
-	if desc == "" {
-		desc = hook.Cmd
-	}
-	report.Info(fmt.Sprintf("Added hook: %s", desc))
-	return report, nil
+	return c.addHook(hook, false)
 }
 
 func (c *Client) RemoveHook(index int) (Report, error) {
-	var report Report
-
-	cfg, configPath, err := c.LoadSharedConfig()
-	if err != nil {
-		return report, err
-	}
-
-	if index < 0 || index >= len(cfg.Hooks) {
-		return report, fmt.Errorf("hook index %d out of range (total: %d)", index, len(cfg.Hooks))
-	}
-
-	removed := cfg.Hooks[index]
-	cfg.Hooks = append(cfg.Hooks[:index], cfg.Hooks[index+1:]...)
-
-	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
-		return report, err
-	}
-
-	desc := removed.Desc
-	if desc == "" {
-		desc = removed.Cmd
-	}
-	report.Info(fmt.Sprintf("Removed hook: %s", desc))
-	return report, nil
+	return c.removeHook(index, false)
 }
 
 func (c *Client) SyncAllSharedResources() (Report, error) {
@@ -365,15 +300,17 @@ func (c *Client) SyncAllSharedResources() (Report, error) {
 	}
 
 	report.Info(fmt.Sprintf("Syncing resources to %d worktrees...", len(targets)))
+	var failures []error
 	for _, wt := range targets {
 		resourceReport, err := c.syncSharedResourcesToPath(wt.Path, false)
 		report.Merge(resourceReport)
 		if err != nil {
 			report.Warn(fmt.Sprintf("Warning: failed to sync %s: %v", filepath.Base(wt.Path), err))
+			failures = append(failures, fmt.Errorf("sync %s: %w", filepath.Base(wt.Path), err))
 		}
 	}
 
-	return report, nil
+	return report, errors.Join(failures...)
 }
 
 func (c *Client) resolveWorktreePath(worktreeName string) (string, error) {
@@ -481,8 +418,29 @@ func (c *Client) resolveSharedPaths(
 		return "", "", false, err
 	}
 
+	roots, rootsErr := c.sharedSourceRoots()
+	if rootsErr != nil {
+		return "", "", false, rootsErr
+	}
+	if res.worktreeRelative {
+		roots = c.primarySharedRoots(roots)
+		if len(roots) == 0 {
+			return "", targetPath, true, nil
+		}
+		repoRoot = roots[0]
+	}
+	for _, root := range roots {
+		if _, statErr := os.Lstat(filepath.Join(root, ".git")); statErr != nil {
+			continue
+		}
+		candidate := filepath.Join(root, targetPath)
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate, targetPath, false, nil
+		}
+	}
+
 	parts := strings.SplitN(res.Path, string(filepath.Separator), 2)
-	if len(parts) == 2 {
+	if len(parts) == 2 && !res.worktreeRelative {
 		worktrees, listErr := c.ListCached()
 		if listErr == nil {
 			var baseMatches []string
@@ -512,9 +470,8 @@ func (c *Client) resolveSharedPaths(
 		return srcPath, targetPath, false, nil
 	}
 
-	currentRoot := c.currentTopLevel()
-	if currentRoot != "" {
-		candidate := filepath.Join(currentRoot, targetPath)
+	for _, root := range roots {
+		candidate := filepath.Join(root, targetPath)
 		if _, statErr := os.Stat(candidate); statErr == nil {
 			return candidate, targetPath, false, nil
 		}
@@ -597,7 +554,7 @@ func (c *Client) runHooks(worktreeRoot string, hooks []Hook, report *Report) err
 	}
 
 	for _, hook := range hooks {
-		if hook.Cmd == "" {
+		if hook.Disabled || hook.Cmd == "" {
 			continue
 		}
 

--- a/internal/worktree/resource_nonbare_test.go
+++ b/internal/worktree/resource_nonbare_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,180 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGlobalPreparationPreservesConfigAndRepositoryOverrides(t *testing.T) {
+	repoDir := initTestRepo(t)
+	t.Chdir(repoDir)
+	globalPath := filepath.Join(t.TempDir(), "config.yaml")
+	globalYAML := []byte("model: example-model\napi_key: fixture-only\nother:\n  enabled: true\n" +
+		"worktree: &preparation\n  shared: []\n  hooks: []\npreparation_view: *preparation\n")
+	configTarget := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configTarget, globalYAML, 0o600))
+	require.NoError(t, os.Symlink(configTarget, globalPath))
+	client := NewClient(Options{GlobalConfigPath: globalPath})
+	_, err := client.AddGlobalSharedResource("**/node_modules", StrategySymlink)
+	require.NoError(t, err)
+	_, err = client.AddGlobalSharedResource(".local", StrategySymlink)
+	require.NoError(t, err)
+	_, err = client.AddGlobalHook(Hook{ID: "prepare", Cmd: "test -L .local && printf global > prepared"})
+	require.NoError(t, err)
+	_, err = client.AddGlobalHook(Hook{ID: "disabled", Cmd: "touch must-not-exist"})
+	require.NoError(t, err)
+	_, err = client.AddHook(Hook{ID: "prepare", Cmd: "test -L .local && printf local > prepared"})
+	require.NoError(t, err)
+	_, err = client.RemoveHookByID("disabled", false)
+	require.NoError(t, err)
+	_, err = client.RemoveSharedResource("web/node_modules")
+	require.NoError(t, err)
+	for _, dir := range []string{".local", "web/node_modules", "other/node_modules"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(repoDir, dir), 0o755))
+	}
+	target := t.TempDir()
+	_, err = client.syncSharedResourcesToPath(target, true)
+	require.NoError(t, err)
+	prepared, err := os.ReadFile(filepath.Join(target, "prepared"))
+	require.NoError(t, err)
+	assert.Equal(t, "local", string(prepared))
+	_, err = os.Readlink(filepath.Join(target, "other/node_modules"))
+	require.NoError(t, err)
+	_, err = os.Lstat(filepath.Join(target, "web/node_modules"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(target, "must-not-exist"))
+	assert.True(t, os.IsNotExist(err))
+	globalData, err := os.ReadFile(globalPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(globalData), "api_key: fixture-only")
+	assert.Contains(t, string(globalData), "example-model")
+	assert.Contains(t, string(globalData), "enabled: true")
+	assert.NotContains(t, string(globalData), "printf local")
+	resolvedConfig, err := os.Readlink(globalPath)
+	require.NoError(t, err)
+	assert.Equal(t, configTarget, resolvedConfig)
+	info, err := os.Stat(globalPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	local, _, err := client.LoadSharedConfig()
+	require.NoError(t, err)
+	require.Len(t, local.Resources, 1)
+	assert.True(t, local.Resources[0].Disabled)
+	assert.Equal(t, "web/node_modules", local.Resources[0].Path)
+	_, err = client.RemoveSharedResource("**/node_modules")
+	require.NoError(t, err)
+	exemptTarget := t.TempDir()
+	_, err = client.syncSharedResourcesToPath(exemptTarget, false)
+	require.NoError(t, err)
+	linked, err := os.Lstat(filepath.Join(exemptTarget, ".local"))
+	require.NoError(t, err)
+	assert.NotZero(t, linked.Mode()&os.ModeSymlink)
+	_, err = client.RemoveGlobalSharedResource(".local")
+	require.NoError(t, err)
+	_, err = client.RemoveGlobalHook(1)
+	require.NoError(t, err)
+	global, _, err := client.LoadGlobalSharedConfig()
+	require.NoError(t, err)
+	require.Len(t, global.Resources, 1)
+	require.Len(t, global.Hooks, 1)
+}
+
+func TestPreparationExclusionsCoverNestedPatterns(t *testing.T) {
+	repoDir := initTestRepo(t)
+	t.Chdir(repoDir)
+	client := NewClient(Options{})
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "apps/web/node_modules"), 0o755))
+	resources, err := client.expandSharedResources([]SharedResource{
+		{Path: "**/node_modules", Strategy: StrategySymlink, Origin: "global"},
+		{Path: "apps", Disabled: true, Origin: "repository"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resources)
+	_, err = client.expandSharedResources([]SharedResource{
+		{Path: "apps", Strategy: StrategySymlink, Origin: "global"},
+		{Path: "**/node_modules", Disabled: true, Origin: "repository"},
+	})
+	require.Error(t, err)
+	_, configPath, err := client.LoadSharedConfig()
+	require.NoError(t, err)
+	require.NoError(t, client.SaveSharedConfig(&SharedConfig{Resources: []SharedResource{
+		{Path: "apps", Strategy: StrategySymlink},
+		{Path: "**/node_modules", Disabled: true},
+	}}, configPath))
+	_, err = client.SyncAllSharedResources()
+	require.Error(t, err)
+}
+
+func TestPreparationKeepsIndependentAndBrokenResources(t *testing.T) {
+	repoDir := initTestRepo(t)
+	t.Chdir(repoDir)
+	client := NewClient(Options{})
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "node_modules"), 0o755))
+	_, err := client.AddSharedResource("node_modules", StrategySymlink)
+	require.NoError(t, err)
+	target := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(target, "node_modules"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "node_modules/owned"), []byte("preserve"), 0o644))
+	report, err := client.syncSharedResourcesToPath(target, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, report.Events)
+	assert.Equal(t, EventWarn, report.Events[0].Level)
+	data, err := os.ReadFile(filepath.Join(target, "node_modules/owned"))
+	require.NoError(t, err)
+	assert.Equal(t, "preserve", string(data))
+	broken := t.TempDir()
+	require.NoError(t, os.Symlink("missing-source", filepath.Join(broken, "node_modules")))
+	report, err = client.syncSharedResourcesToPath(broken, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, report.Events)
+	assert.Equal(t, EventWarn, report.Events[0].Level)
+	link, err := os.Readlink(filepath.Join(broken, "node_modules"))
+	require.NoError(t, err)
+	assert.Equal(t, "missing-source", link)
+}
+
+func TestPreparationRejectsTrackedContentAndSymlinkParents(t *testing.T) {
+	repoDir := initTestRepo(t)
+	t.Chdir(repoDir)
+	client := NewClient(Options{})
+	target := t.TempDir()
+	_, err := client.syncOneResource(repoDir, target, SharedResource{Path: "README.md", Strategy: StrategySymlink})
+	require.Error(t, err)
+	_, err = os.Lstat(filepath.Join(target, "README.md"))
+	assert.True(t, os.IsNotExist(err))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "app/node_modules"), 0o755))
+	external := t.TempDir()
+	require.NoError(t, os.Symlink(external, filepath.Join(target, "app")))
+	_, err = client.syncOneResource(repoDir, target, SharedResource{Path: "app/node_modules", Strategy: StrategySymlink})
+	require.Error(t, err)
+	_, err = os.Lstat(filepath.Join(external, "node_modules"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestGlobalConfigInvalidEditDoesNotChangeFile(t *testing.T) {
+	globalPath := filepath.Join(t.TempDir(), "config.yaml")
+	original := []byte("model: preserve\nworktree:\n  hooks:\n    - id: setup\n      cmd: echo ok\n")
+	require.NoError(t, os.WriteFile(globalPath, original, 0o600))
+	client := NewClient(Options{GlobalConfigPath: globalPath})
+	_, err := client.AddGlobalSharedResource(".git/config", StrategySymlink)
+	require.Error(t, err)
+	_, err = client.AddGlobalHook(Hook{ID: "2", Cmd: "echo no"})
+	require.Error(t, err)
+	after, err := os.ReadFile(globalPath)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(original, after))
+	anchored := []byte("worktree:\n  hooks:\n    - &saved\n      id: saved\n      cmd: true\nother: *saved\n")
+	require.NoError(t, os.WriteFile(globalPath, anchored, 0o600))
+	_, err = client.AddGlobalSharedResource(".local", StrategySymlink)
+	require.Error(t, err)
+	unchanged, err := os.ReadFile(globalPath)
+	require.NoError(t, err)
+	assert.Equal(t, anchored, unchanged)
+	multiple := []byte("worktree: {}\n---\nother: preserve\n")
+	require.NoError(t, os.WriteFile(globalPath, multiple, 0o600))
+	_, err = client.AddGlobalSharedResource(".local", StrategySymlink)
+	require.Error(t, err)
+	unchanged, err = os.ReadFile(globalPath)
+	require.NoError(t, err)
+	assert.Equal(t, multiple, unchanged)
+}
 
 func TestLoadSharedConfig_UsesGitCommonDirInNonBareWorktree(t *testing.T) {
 	repoDir := initTestRepo(t)
@@ -150,4 +325,120 @@ func TestResolveWorktreePath_ErrorsOnAmbiguousBasename(t *testing.T) {
 	_, err = client.resolveWorktreePath("dup")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ambiguous worktree")
+}
+
+func TestPreparationPreservesNestedPathsMatchingWorktreeNames(t *testing.T) {
+	repo := initTestRepo(t)
+	t.Chdir(repo)
+	client := NewClient(Options{})
+	_, err := client.Add("web", AddOptions{})
+	require.NoError(t, err)
+	worktrees, err := client.ListCached()
+	require.NoError(t, err)
+	var target string
+	for _, wt := range worktrees {
+		if wt.Branch == "web" {
+			target = wt.Path
+		}
+	}
+	require.NotEmpty(t, target)
+	relative := filepath.Join(filepath.Base(target), "node_modules")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, relative), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, relative, "package"), []byte("nested"), 0o644))
+	_, err = client.AddSharedResource("**/node_modules", StrategySymlink)
+	require.NoError(t, err)
+	_, err = client.SyncAllSharedResources()
+	require.NoError(t, err)
+	data, err := os.ReadFile(filepath.Join(target, relative, "package"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(data))
+	_, err = os.Lstat(filepath.Join(target, "node_modules"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = client.RemoveSharedResource("**/node_modules")
+	require.NoError(t, err)
+	_, err = client.AddSharedResource(relative, StrategySymlink)
+	require.NoError(t, err)
+	_, err = client.SyncAllSharedResources()
+	require.NoError(t, err)
+	_, err = os.Lstat(filepath.Join(target, "node_modules"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDiscoverReportsBrokenSourceLink(t *testing.T) {
+	repo := initTestRepo(t)
+	t.Chdir(repo)
+	client := NewClient(Options{})
+	_, err := client.AddSharedResource(".local", StrategySymlink)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink("missing", filepath.Join(repo, ".local")))
+	results, err := client.Discover(DiscoverOptions{IncludeConfigured: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "broken-link", results[0].TargetState)
+	require.NoError(t, os.Mkdir(filepath.Join(repo, "missing"), 0o755))
+	results, err = client.Discover(DiscoverOptions{IncludeConfigured: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "source", results[0].TargetState)
+}
+
+func TestAutomaticSharingDoesNotBorrowTransientSources(t *testing.T) {
+	repo := initTestRepo(t)
+	t.Chdir(repo)
+	client := NewClient(Options{GlobalConfigPath: filepath.Join(t.TempDir(), "global.yaml")})
+	_, err := client.Add("feature", AddOptions{})
+	require.NoError(t, err)
+	worktrees, err := client.ListCached()
+	require.NoError(t, err)
+	var feature string
+	for _, wt := range worktrees {
+		if wt.Branch == "feature" {
+			feature = wt.Path
+		}
+	}
+	require.NotEmpty(t, feature)
+	for _, relative := range []string{"pkg/node_modules", ".local"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(feature, relative), 0o755))
+	}
+	_, err = client.AddGlobalSharedResource("**/node_modules", StrategySymlink)
+	require.NoError(t, err)
+	_, err = client.AddGlobalSharedResource(".local", StrategySymlink)
+	require.NoError(t, err)
+	_, err = client.SyncAllSharedResources()
+	require.NoError(t, err)
+	for _, relative := range []string{"pkg", ".local"} {
+		_, err = os.Lstat(filepath.Join(repo, relative))
+		assert.True(t, os.IsNotExist(err))
+	}
+	results, err := client.Discover(DiscoverOptions{IncludeConfigured: true})
+	require.NoError(t, err)
+	var inspected bool
+	for _, result := range results {
+		if result.Path == "pkg/node_modules" {
+			inspected = true
+			assert.Equal(t, filepath.Join(feature, "pkg/node_modules"), result.Source)
+			assert.Equal(t, "missing", result.TargetState)
+		}
+	}
+	assert.True(t, inspected)
+	_, err = client.Add("consumer", AddOptions{})
+	require.NoError(t, err)
+	for _, relative := range []string{"pkg/node_modules", ".local"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, relative), 0o755))
+	}
+	_, err = client.SyncAllSharedResources()
+	require.NoError(t, err)
+	worktrees, err = client.ListCached()
+	require.NoError(t, err)
+	for _, wt := range worktrees {
+		if wt.Branch == "consumer" {
+			for _, relative := range []string{"pkg/node_modules", ".local"} {
+				resolved, err := filepath.EvalSymlinks(filepath.Join(wt.Path, relative))
+				require.NoError(t, err)
+				expected, err := filepath.EvalSymlinks(filepath.Join(repo, relative))
+				require.NoError(t, err)
+				assert.Equal(t, expected, resolved)
+			}
+		}
+	}
 }

--- a/internal/worktree/share_discover.go
+++ b/internal/worktree/share_discover.go
@@ -5,117 +5,244 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/samzong/gmc/internal/gitcmd"
 )
 
 var copyCandidates = []string{
-	".env",
-	".env.local",
-	".env.development",
-	".env.production",
-	".claude/settings.json",
-	".claude/CLAUDE.md",
-	".serena/project.yml",
+	".env", ".env.local", ".env.development", ".env.production",
+	".claude/settings.json", ".claude/CLAUDE.md", ".serena/project.yml",
 }
 
-var linkCandidates = []string{
-	"node_modules",
-	".venv",
-	"vendor",
-	"__pycache__",
-}
+var managedDirectories = []string{"node_modules", ".venv", "venv", "vendor", "__pycache__"}
 
 type DiscoverOptions struct {
-	MainWorktreePath string
+	MainWorktreePath  string
+	IncludeConfigured bool
 }
 
 type DiscoverResult struct {
-	Path     string           `json:"path"`
-	Strategy ResourceStrategy `json:"strategy"`
-	Reason   string           `json:"reason"`
+	Path           string           `json:"path"`
+	Strategy       ResourceStrategy `json:"strategy,omitempty"`
+	Reason         string           `json:"reason"`
+	Source         string           `json:"source,omitempty"`
+	Status         string           `json:"status"`
+	SizeBytes      int64            `json:"size_bytes"`
+	SizeLimited    bool             `json:"size_limited,omitempty"`
+	Project        string           `json:"project,omitempty"`
+	Ecosystem      string           `json:"ecosystem,omitempty"`
+	PackageManager string           `json:"package_manager,omitempty"`
+	ConfiguredBy   string           `json:"configured_by,omitempty"`
+	TargetState    string           `json:"target_state,omitempty"`
+	ProjectMarker  bool             `json:"-"`
 }
 
 func (c *Client) Discover(opts DiscoverOptions) ([]DiscoverResult, error) {
-	cfg, _, err := c.LoadSharedConfig()
+	cfg, err := c.LoadEffectiveSharedConfig()
 	if err != nil {
 		return nil, err
 	}
-
-	existing := make(map[string]bool, len(cfg.Resources))
-	for _, res := range cfg.Resources {
-		existing[res.Path] = true
-	}
-
-	mainPath := opts.MainWorktreePath
-	if mainPath == "" {
-		mainPath, err = c.findMainWorktreePath()
+	roots := []string{opts.MainWorktreePath}
+	if opts.MainWorktreePath == "" {
+		roots, err = c.sharedSourceRoots()
 		if err != nil {
 			return nil, err
 		}
 	}
-
+	primary := ""
+	if opts.MainWorktreePath != "" {
+		primary = opts.MainWorktreePath
+	} else if primaryRoots := c.primarySharedRoots(roots); len(primaryRoots) > 0 {
+		primary = primaryRoots[0]
+		for _, root := range roots {
+			if root != primary {
+				primaryRoots = append(primaryRoots, root)
+			}
+		}
+		roots = primaryRoots
+	}
+	current := c.currentTopLevel()
+	seen := make(map[string]bool)
 	var results []DiscoverResult
-
-	for _, candidate := range copyCandidates {
-		if existing[candidate] {
-			continue
+	for _, root := range roots {
+		tracked, err := discoverTrackedPaths(root)
+		if err != nil {
+			return nil, err
 		}
-		if _, statErr := os.Stat(filepath.Join(mainPath, candidate)); statErr == nil {
+		entries, projects, err := scanShareProjects(root, cfg.Resources)
+		if err != nil {
+			return nil, err
+		}
+		paths := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			paths = append(paths, entry.Path)
+		}
+		for _, entry := range entries {
+			if seen[entry.Path] {
+				continue
+			}
+			seen[entry.Path] = true
+			entry.Source = filepath.Join(root, filepath.FromSlash(entry.Path))
+			if entry.Status == "" {
+				entry.Status = "candidate"
+			}
+			if project, ok := nearestShareProject(entry.Path, projects); ok {
+				entry.Project, entry.Ecosystem, entry.PackageManager = project.Project, project.Ecosystem, project.PackageManager
+			}
+			if rule, ok := discoverCoveringRule(cfg.Resources, entry.Path); ok {
+				entry.ConfiguredBy = rule.Path
+				entry.Strategy = rule.Strategy
+				entry.Status = "configured"
+				entry.Reason = "covered by " + rule.Origin + " rule " + rule.Path
+				if !rule.Disabled && sharedRuleUsesPrimary(rule) && root != primary {
+					entry.Reason += "; source exists outside the primary worktree; not applied automatically"
+				}
+				if rule.Disabled {
+					entry.Status, entry.Reason = "excluded", "excluded by rule "+rule.Path
+				} else {
+					parent := rule
+					parent.Path = entry.Path
+					if excluded := sharedExcludedChild(cfg.Resources, parent, paths); excluded != "" {
+						entry.Reason += "; conflicts with excluded child " + excluded +
+							"; disable the parent and share selected children"
+					}
+				}
+			}
+			for _, path := range tracked {
+				if path == entry.Path || strings.HasPrefix(path, entry.Path+"/") {
+					entry.Status, entry.Reason = "tracked", "contains Git-tracked content; keep it in each worktree"
+					break
+				}
+			}
+			if !opts.IncludeConfigured && entry.Status != "candidate" {
+				continue
+			}
+			entry.SizeBytes, entry.SizeLimited = discoverLogicalSize(entry.Source)
+			entry.TargetState = discoverTargetState(current, entry.Path, entry.Source)
+			results = append(results, entry)
+		}
+		if opts.IncludeConfigured {
+			for _, project := range projects {
+				key := project.Path + ":" + project.Ecosystem
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				project.Source = filepath.Join(root, filepath.FromSlash(project.Path))
+				project.ProjectMarker = true
+				project.SizeBytes, project.SizeLimited = discoverLogicalSize(project.Source)
+				project.TargetState = discoverTargetState(current, project.Path, project.Source)
+				results = append(results, project)
+			}
+		}
+	}
+	if opts.IncludeConfigured {
+		for _, rule := range cfg.Resources {
+			if seen[rule.Path] || strings.ContainsAny(rule.Path, "*?[") {
+				continue
+			}
+			status := "configured"
+			if rule.Disabled {
+				status = "excluded"
+			}
 			results = append(results, DiscoverResult{
-				Path:     candidate,
-				Strategy: StrategyCopy,
-				Reason:   "config/env file — isolated copy per worktree",
+				Path: rule.Path, Strategy: rule.Strategy, Status: status, ConfiguredBy: rule.Path,
+				Reason: "no source found in scanned worktrees", TargetState: discoverTargetState(current, rule.Path, ""),
 			})
 		}
 	}
-
-	for _, candidate := range linkCandidates {
-		if existing[candidate] {
-			continue
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Path == results[j].Path {
+			return results[i].Status < results[j].Status
 		}
-		if _, statErr := os.Stat(filepath.Join(mainPath, candidate)); statErr == nil {
-			results = append(results, DiscoverResult{
-				Path:     candidate,
-				Strategy: StrategySymlink,
-				Reason:   "dependency/cache directory — shared symlink saves disk",
-			})
-		}
-	}
-
+		return results[i].Path < results[j].Path
+	})
 	return results, nil
+}
+
+func discoverCoveringRule(resources []SharedResource, path string) (SharedResource, bool) {
+	return sharedRuleForPath(resources, path, true)
+}
+
+func discoverTrackedPaths(root string) ([]string, error) {
+	if _, err := os.Lstat(filepath.Join(root, ".git")); os.IsNotExist(err) {
+		return nil, nil
+	}
+	result, err := (gitcmd.Runner{Dir: root}).Run("ls-files", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("inspect tracked files in %s: %w", root, err)
+	}
+	return strings.Split(string(result.Stdout), "\x00"), nil
+}
+
+func discoverTargetState(root, path, source string) string {
+	if root == "" {
+		return ""
+	}
+	target := filepath.Join(root, filepath.FromSlash(path))
+	info, err := os.Lstat(target)
+	if os.IsNotExist(err) {
+		return "missing"
+	}
+	if err != nil {
+		return "unreadable"
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		resolved, err := filepath.EvalSymlinks(target)
+		if err != nil {
+			return "broken-link"
+		}
+		if target == source {
+			return "source"
+		}
+		resolvedSource, _ := filepath.EvalSymlinks(source)
+		if resolved == resolvedSource {
+			return "shared-link"
+		}
+		return "other-link"
+	}
+	if target == source {
+		return "source"
+	}
+	return "independent"
 }
 
 func (c *Client) AddDiscoveredResources(results []DiscoverResult) (Report, error) {
 	var report Report
-
 	if len(results) == 0 {
 		return report, nil
 	}
-
 	cfg, configPath, err := c.LoadSharedConfig()
 	if err != nil {
 		return report, err
 	}
-
-	existing := make(map[string]bool, len(cfg.Resources))
-	for _, res := range cfg.Resources {
-		existing[res.Path] = true
+	effective, err := c.LoadEffectiveSharedConfig()
+	if err != nil {
+		return report, err
 	}
-
 	for _, r := range results {
-		if existing[r.Path] {
+		if r.Status != "" && r.Status != "candidate" {
 			continue
 		}
-		cfg.Resources = append(cfg.Resources, SharedResource{
-			Path:     r.Path,
-			Strategy: r.Strategy,
-		})
+		if r.Strategy != StrategyCopy && r.Strategy != StrategySymlink {
+			continue
+		}
+		if _, covered := discoverCoveringRule(effective.Resources, r.Path); covered {
+			continue
+		}
+		resource := SharedResource{Path: r.Path, Strategy: r.Strategy}
+		cfg.Resources = append(cfg.Resources, resource)
+		effective.Resources = append(effective.Resources, resource)
 		report.Info(fmt.Sprintf("Added shared resource: %s (%s)", r.Path, r.Strategy))
 	}
-
+	if len(report.Events) == 0 {
+		return report, nil
+	}
 	if err := c.SaveSharedConfig(cfg, configPath); err != nil {
 		return report, err
 	}
-
 	return report, nil
 }
 
@@ -124,7 +251,6 @@ func (c *Client) findMainWorktreePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to list worktrees: %w", err)
 	}
-
 	mainBranch, err := c.resolvedMainBranch()
 	if err == nil && mainBranch != "" {
 		for _, wt := range worktrees {
@@ -133,13 +259,10 @@ func (c *Client) findMainWorktreePath() (string, error) {
 			}
 		}
 	}
-
 	for _, wt := range worktrees {
 		if !wt.IsBare && filepath.Base(wt.Path) != ".bare" {
-			fmt.Fprintf(os.Stderr, "Warning: no main/master branch found, using worktree %q\n", filepath.Base(wt.Path))
 			return wt.Path, nil
 		}
 	}
-
 	return "", errors.New("no worktree found to scan")
 }

--- a/internal/worktree/share_discover_test.go
+++ b/internal/worktree/share_discover_test.go
@@ -30,7 +30,7 @@ func TestDiscover_FindsCandidates(t *testing.T) {
 	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
 	require.NoError(t, err)
 
-	assert.Len(t, results, 3)
+	assert.Len(t, results, 2)
 
 	paths := make(map[string]ResourceStrategy)
 	for _, r := range results {
@@ -38,7 +38,7 @@ func TestDiscover_FindsCandidates(t *testing.T) {
 	}
 	assert.Equal(t, StrategyCopy, paths[".env"])
 	assert.Equal(t, StrategyCopy, paths[".claude/CLAUDE.md"])
-	assert.Equal(t, StrategySymlink, paths["node_modules"])
+	assert.NotContains(t, paths, "node_modules")
 }
 
 func TestDiscover_SkipsExisting(t *testing.T) {
@@ -66,9 +66,7 @@ func TestDiscover_SkipsExisting(t *testing.T) {
 	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
 	require.NoError(t, err)
 
-	assert.Len(t, results, 1)
-	assert.Equal(t, "node_modules", results[0].Path)
-	assert.Equal(t, StrategySymlink, results[0].Strategy)
+	assert.Empty(t, results)
 }
 
 func TestDiscover_EmptyWorktree(t *testing.T) {
@@ -118,33 +116,6 @@ func TestDiscover_AllCopyCandidates(t *testing.T) {
 	assert.Equal(t, len(copyCandidates), copyCount)
 }
 
-func TestDiscover_AllLinkCandidates(t *testing.T) {
-	mainWT := t.TempDir()
-
-	for _, c := range linkCandidates {
-		require.NoError(t, os.Mkdir(filepath.Join(mainWT, c), 0755))
-	}
-
-	repoDir := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(repoDir, ".bare"), 0755))
-
-	oldCwd, _ := os.Getwd()
-	require.NoError(t, os.Chdir(repoDir))
-	defer func() { _ = os.Chdir(oldCwd) }()
-
-	client := NewClient(Options{})
-	results, err := client.Discover(DiscoverOptions{MainWorktreePath: mainWT})
-	require.NoError(t, err)
-
-	var linkCount int
-	for _, r := range results {
-		if r.Strategy == StrategySymlink {
-			linkCount++
-		}
-	}
-	assert.Equal(t, len(linkCandidates), linkCount)
-}
-
 func TestAddDiscoveredResources_Batch(t *testing.T) {
 	repoDir := t.TempDir()
 	bareDir := filepath.Join(repoDir, ".bare")
@@ -172,4 +143,177 @@ func TestAddDiscoveredResources_Batch(t *testing.T) {
 	assert.Equal(t, StrategyCopy, cfg.Resources[0].Strategy)
 	assert.Equal(t, "node_modules", cfg.Resources[1].Path)
 	assert.Equal(t, StrategySymlink, cfg.Resources[1].Strategy)
+}
+
+func TestDiscover_MonorepoProjectsAndTraversalBoundaries(t *testing.T) {
+	repo := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(repo, ".bare"), 0755))
+	t.Chdir(repo)
+	root := t.TempDir()
+	files := map[string]string{
+		"apps/web/package.json":                               "{}",
+		"apps/web/pnpm-lock.yaml":                             "lockfileVersion: '9.0'",
+		"apps/web/node_modules/pkg/index.js":                  "module.exports = 1",
+		"services/api/pyproject.toml":                         "[project]",
+		"services/api/uv.lock":                                "version = 1",
+		"services/api/.venv/lib/package.py":                   "x = 1",
+		"services/gateway/go.mod":                             "module example.org/gateway",
+		"crates/worker/Cargo.toml":                            "[package]",
+		"crates/worker/target/fake/package.json":              "{}",
+		"crates/worker/target/fake/node_modules/pkg/index.js": "x",
+		".local/scratch/node_modules/pkg/index.js":            "x",
+		"apps/web/node_modules/pkg/.env":                      "X=1",
+		"nested/.git/HEAD":                                    "ref: refs/heads/main",
+		"nested/node_modules/pkg/index.js":                    "x",
+	}
+	for path, content := range files {
+		full := filepath.Join(root, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	}
+	external := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(external, "node_modules"), 0755))
+	require.NoError(t, os.Symlink(external, filepath.Join(root, "external")))
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: root, IncludeConfigured: true})
+	require.NoError(t, err)
+	var candidates []DiscoverResult
+	byPath := make(map[string]DiscoverResult)
+	var buildArtifact DiscoverResult
+	projects := make(map[string]DiscoverResult)
+	for _, result := range results {
+		byPath[result.Path] = result
+		if result.Path == "crates/worker/target" {
+			buildArtifact = result
+		}
+		if result.Status == "candidate" {
+			candidates = append(candidates, result)
+		}
+		if result.Status == "managed" && result.Project != "" {
+			projects[result.Project] = result
+		}
+	}
+	assert.Equal(t, "managed", buildArtifact.Status)
+	assert.Greater(t, buildArtifact.SizeBytes, int64(0))
+	assert.Empty(t, buildArtifact.Strategy)
+	assert.Empty(t, candidates)
+	node := byPath["apps/web/node_modules"]
+	assert.Equal(t, "managed", node.Status)
+	assert.Empty(t, node.Strategy)
+	assert.Equal(t, "pnpm", node.PackageManager)
+	packageBytes := len(files["apps/web/node_modules/pkg/index.js"]) + len(files["apps/web/node_modules/pkg/.env"])
+	assert.Equal(t, int64(packageBytes), node.SizeBytes)
+	python := byPath["services/api/.venv"]
+	assert.Equal(t, "managed", python.Status)
+	assert.Empty(t, python.Strategy)
+	assert.Equal(t, "uv", python.PackageManager)
+	require.Len(t, projects, 4)
+	assert.Equal(t, "Go", projects["services/gateway"].Ecosystem)
+	assert.Equal(t, "Rust", projects["crates/worker"].Ecosystem)
+	_, err = client.AddDiscoveredResources(results)
+	require.NoError(t, err)
+	cfg, _, err := client.LoadSharedConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Resources)
+}
+
+func TestDiscover_ParentCoverageAndExclusions(t *testing.T) {
+	repo := t.TempDir()
+	bare := filepath.Join(repo, ".bare")
+	require.NoError(t, os.Mkdir(bare, 0755))
+	t.Chdir(repo)
+	root := t.TempDir()
+	for _, path := range []string{".serena/project.yml", "apps/web/node_modules/pkg/index.js", ".local/result.txt"} {
+		full := filepath.Join(root, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte("data"), 0644))
+	}
+	cfg := SharedConfig{Resources: []SharedResource{
+		{Path: ".serena", Strategy: StrategySymlink},
+		{Path: "**/node_modules", Strategy: StrategySymlink, Disabled: true},
+		{Path: ".local", Strategy: StrategySymlink},
+	}}
+	client := NewClient(Options{})
+	require.NoError(t, client.SaveSharedConfig(&cfg, filepath.Join(bare, "gmc-share.yml")))
+	candidates, err := client.Discover(DiscoverOptions{MainWorktreePath: root})
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: root, IncludeConfigured: true})
+	require.NoError(t, err)
+	byPath := make(map[string]DiscoverResult)
+	for _, result := range results {
+		byPath[result.Path] = result
+	}
+	assert.Equal(t, "configured", byPath[".serena/project.yml"].Status)
+	assert.Equal(t, ".serena", byPath[".serena/project.yml"].ConfiguredBy)
+	assert.Equal(t, "excluded", byPath["apps/web/node_modules"].Status)
+	assert.Equal(t, "configured", byPath[".local"].Status)
+	report, err := client.AddDiscoveredResources(results)
+	require.NoError(t, err)
+	assert.Empty(t, report.Events)
+}
+
+func TestDiscover_TrackedContentCannotBecomeShared(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.name", "Test")
+	runGit(t, root, "config", "user.email", "test@example.org")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "vendor", "pkg"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "vendor", "pkg", "source.go"), []byte("package pkg"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".env"), []byte("X=1"), 0644))
+	runGit(t, root, "add", "vendor")
+	t.Chdir(root)
+	client := NewClient(Options{})
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: root, IncludeConfigured: true})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "candidate", results[0].Status)
+	assert.Equal(t, "tracked", results[1].Status)
+	_, err = client.AddDiscoveredResources(results)
+	require.NoError(t, err)
+	cfg, _, err := client.LoadSharedConfig()
+	require.NoError(t, err)
+	require.Len(t, cfg.Resources, 1)
+	assert.Equal(t, ".env", cfg.Resources[0].Path)
+}
+
+func TestDiscover_ExplicitResourceInsidePrunedDirectoryAndInheritedManager(t *testing.T) {
+	repo := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(repo, ".bare"), 0755))
+	t.Chdir(repo)
+	root := t.TempDir()
+	for path, content := range map[string]string{
+		"pnpm-lock.yaml":                         "lockfileVersion: '9.0'",
+		"apps/web/package.json":                  "{}",
+		"apps/web/node_modules/package/index.js": "module.exports = 1",
+		".local/reports/latest.json":             "{}",
+	} {
+		full := filepath.Join(root, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	}
+	client := NewClient(Options{})
+	_, err := client.AddSharedResource(".local/reports/latest.json", StrategyCopy)
+	require.NoError(t, err)
+	results, err := client.Discover(DiscoverOptions{MainWorktreePath: root, IncludeConfigured: true})
+	require.NoError(t, err)
+	byPath := make(map[string]DiscoverResult)
+	for _, result := range results {
+		byPath[result.Path] = result
+	}
+	assert.Equal(t, "configured", byPath[".local/reports/latest.json"].Status)
+	assert.Equal(t, filepath.Join(root, ".local/reports/latest.json"), byPath[".local/reports/latest.json"].Source)
+	assert.Equal(t, "pnpm", byPath["apps/web/node_modules"].PackageManager)
+	assert.Equal(t, "pnpm", byPath["apps/web/package.json"].PackageManager)
+	_, err = client.AddSharedResource("**/node_modules", StrategySymlink)
+	require.NoError(t, err)
+	results, err = client.Discover(DiscoverOptions{MainWorktreePath: root, IncludeConfigured: true})
+	require.NoError(t, err)
+	for _, result := range results {
+		if result.Path == "apps/web/node_modules" {
+			assert.Equal(t, "configured", result.Status)
+			assert.Equal(t, StrategySymlink, result.Strategy)
+			assert.Equal(t, "**/node_modules", result.ConfiguredBy)
+		}
+	}
 }

--- a/internal/worktree/shared_config.go
+++ b/internal/worktree/shared_config.go
@@ -1,0 +1,405 @@
+package worktree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (c *Client) LoadGlobalSharedConfig() (*SharedConfig, string, error) {
+	var document struct {
+		Worktree SharedConfig `yaml:"worktree"`
+	}
+	if c.globalConfigPath == "" {
+		return &document.Worktree, "", nil
+	}
+	data, err := os.ReadFile(c.globalConfigPath)
+	if os.IsNotExist(err) {
+		return &document.Worktree, c.globalConfigPath, nil
+	}
+	if err != nil {
+		return nil, c.globalConfigPath, fmt.Errorf("read global worktree config: %w", err)
+	}
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil, c.globalConfigPath, fmt.Errorf("parse global worktree config: %w", err)
+	}
+	return &document.Worktree, c.globalConfigPath, nil
+}
+
+func (c *Client) LoadEffectiveSharedConfig() (*SharedConfig, error) {
+	global, _, err := c.LoadGlobalSharedConfig()
+	if err != nil {
+		return nil, err
+	}
+	local, _, err := c.LoadSharedConfig()
+	if err != nil {
+		return nil, err
+	}
+	var merged SharedConfig
+	resourceIndex := make(map[string]int)
+	hookIndex := make(map[string]int)
+	for i, cfg := range []*SharedConfig{global, local} {
+		origin := "global"
+		if i == 1 {
+			origin = "repository"
+		}
+		if err := validateSharedConfig(cfg); err != nil {
+			return nil, fmt.Errorf("%s worktree config: %w", origin, err)
+		}
+		for _, res := range cfg.Resources {
+			res.Path = filepath.ToSlash(filepath.Clean(res.Path))
+			res.Origin = origin
+			if index, ok := resourceIndex[res.Path]; ok {
+				merged.Resources[index] = res
+			} else {
+				resourceIndex[res.Path] = len(merged.Resources)
+				merged.Resources = append(merged.Resources, res)
+			}
+		}
+		for _, hook := range cfg.Hooks {
+			hook.Origin = origin
+			key := hookKey(hook)
+			if index, ok := hookIndex[key]; ok {
+				merged.Hooks[index] = hook
+			} else {
+				hookIndex[key] = len(merged.Hooks)
+				merged.Hooks = append(merged.Hooks, hook)
+			}
+		}
+	}
+	return &merged, nil
+}
+
+func validateSharedConfig(cfg *SharedConfig) error {
+	paths := make(map[string]bool)
+	for _, res := range cfg.Resources {
+		if err := validateSharedPattern(res.Path); err != nil {
+			return err
+		}
+		key := filepath.ToSlash(filepath.Clean(res.Path))
+		if paths[key] {
+			return fmt.Errorf("duplicate shared resource: %s", res.Path)
+		}
+		paths[key] = true
+		if !res.Disabled && res.Strategy != StrategyCopy && res.Strategy != StrategySymlink {
+			return fmt.Errorf("invalid strategy for %s: %q (use copy or link)", res.Path, res.Strategy)
+		}
+	}
+	ids := make(map[string]bool)
+	for _, hook := range cfg.Hooks {
+		if hook.ID != "" {
+			_, numeric := strconv.Atoi(hook.ID)
+			if numeric == nil || strings.TrimSpace(hook.ID) != hook.ID || strings.ContainsAny(hook.ID, " \t\r\n") {
+				return fmt.Errorf("hook id must be a nonnumeric name without whitespace: %q", hook.ID)
+			}
+			if ids[hook.ID] {
+				return fmt.Errorf("duplicate hook id: %s", hook.ID)
+			}
+			ids[hook.ID] = true
+		}
+		if strings.TrimSpace(hook.Cmd) == "" && (!hook.Disabled || hook.ID == "") {
+			return errors.New("hook requires a command or a disabled named id")
+		}
+	}
+	return nil
+}
+
+func hookKey(hook Hook) string {
+	if hook.ID != "" {
+		return "id:" + hook.ID
+	}
+	return "cmd:" + hook.Cmd
+}
+
+func (c *Client) SaveGlobalSharedConfig(cfg *SharedConfig) error {
+	if c.globalConfigPath == "" {
+		return errors.New("global config path is unavailable")
+	}
+	if err := validateSharedConfig(cfg); err != nil {
+		return err
+	}
+	var document yaml.Node
+	data, err := os.ReadFile(c.globalConfigPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if len(data) > 0 {
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		if err := decoder.Decode(&document); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("parse global config: %w", err)
+		}
+		var trailing yaml.Node
+		if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+			return errors.New("global config must contain a single YAML document")
+		}
+	}
+	if len(document.Content) == 0 {
+		document = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}}
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return errors.New("global config must be a YAML mapping")
+	}
+	var value yaml.Node
+	if err := value.Encode(cfg); err != nil {
+		return err
+	}
+	found := false
+	for i := 0; i < len(root.Content); i += 2 {
+		if root.Content[i].Value == "worktree" {
+			value.Anchor = root.Content[i+1].Anchor
+			root.Content[i+1] = &value
+			found = true
+			break
+		}
+	}
+	if !found {
+		root.Content = append(root.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "worktree"}, &value)
+	}
+	data, err = yaml.Marshal(&document)
+	if err != nil {
+		return err
+	}
+	var checked yaml.Node
+	if err := yaml.Unmarshal(data, &checked); err != nil {
+		return fmt.Errorf("cannot preserve global config references: %w", err)
+	}
+	return writeSharedConfig(c.globalConfigPath, data, 0o600)
+}
+
+func writeSharedConfig(path string, data []byte, mode os.FileMode) error {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return err
+		}
+		path = resolved
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), ".gmc-config-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), path)
+}
+
+func (c *Client) loadSharedScope(global bool) (*SharedConfig, string, error) {
+	if global {
+		return c.LoadGlobalSharedConfig()
+	}
+	return c.LoadSharedConfig()
+}
+
+func (c *Client) saveSharedScope(cfg *SharedConfig, path string, global bool) error {
+	if err := validateSharedConfig(cfg); err != nil {
+		return err
+	}
+	if global {
+		return c.SaveGlobalSharedConfig(cfg)
+	}
+	return c.SaveSharedConfig(cfg, path)
+}
+
+func (c *Client) AddGlobalSharedResource(path string, strategy ResourceStrategy) (Report, error) {
+	return c.addSharedResource(path, strategy, true)
+}
+
+func (c *Client) addSharedResource(path string, strategy ResourceStrategy, global bool) (Report, error) {
+	var report Report
+	if global && filepath.IsAbs(path) {
+		return report, errors.New("global shared paths must be worktree-relative")
+	}
+	path, err := c.NormalizeSharedResourcePath(path)
+	if err != nil {
+		return report, err
+	}
+	cfg, configPath, err := c.loadSharedScope(global)
+	if err != nil {
+		return report, err
+	}
+	resource := SharedResource{Path: filepath.ToSlash(path), Strategy: strategy}
+	found := false
+	for i, existing := range cfg.Resources {
+		if filepath.ToSlash(filepath.Clean(existing.Path)) == resource.Path {
+			cfg.Resources[i] = resource
+			found = true
+			break
+		}
+	}
+	if !found {
+		cfg.Resources = append(cfg.Resources, resource)
+	}
+	if err := c.saveSharedScope(cfg, configPath, global); err != nil {
+		return report, err
+	}
+	report.Info(fmt.Sprintf("Updated shared resource: %s (%s)", path, strategy))
+	return report, nil
+}
+
+func (c *Client) RemoveGlobalSharedResource(path string) (Report, error) {
+	return c.removeSharedResource(path, true)
+}
+
+func (c *Client) removeSharedResource(path string, global bool) (Report, error) {
+	var report Report
+	path, err := c.NormalizeSharedResourcePath(path)
+	if err != nil {
+		return report, err
+	}
+	path = filepath.ToSlash(path)
+	cfg, configPath, err := c.loadSharedScope(global)
+	if err != nil {
+		return report, err
+	}
+	found := false
+	remaining := make([]SharedResource, 0, len(cfg.Resources))
+	for _, resource := range cfg.Resources {
+		if filepath.ToSlash(filepath.Clean(resource.Path)) == path {
+			found = true
+		} else {
+			remaining = append(remaining, resource)
+		}
+	}
+	if !global {
+		defaults, _, err := c.LoadGlobalSharedConfig()
+		if err != nil {
+			return report, err
+		}
+		for _, resource := range defaults.Resources {
+			if resource.Path == path || MatchSharedPath(resource.Path, path) {
+				remaining = append(remaining, SharedResource{Path: path, Disabled: true})
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		return report, fmt.Errorf("resource not found in config: %s", path)
+	}
+	cfg.Resources = remaining
+	if err := c.saveSharedScope(cfg, configPath, global); err != nil {
+		return report, err
+	}
+	report.Info("Removed or disabled shared resource: " + path)
+	return report, nil
+}
+
+func (c *Client) AddGlobalHook(hook Hook) (Report, error) {
+	return c.addHook(hook, true)
+}
+
+func (c *Client) addHook(hook Hook, global bool) (Report, error) {
+	var report Report
+	cfg, configPath, err := c.loadSharedScope(global)
+	if err != nil {
+		return report, err
+	}
+	found := false
+	for i, existing := range cfg.Hooks {
+		if hookKey(existing) == hookKey(hook) {
+			cfg.Hooks[i] = hook
+			found = true
+			break
+		}
+	}
+	if !found {
+		cfg.Hooks = append(cfg.Hooks, hook)
+	}
+	if err := c.saveSharedScope(cfg, configPath, global); err != nil {
+		return report, err
+	}
+	label := hook.Desc
+	if label == "" {
+		label = hook.Cmd
+	}
+	report.Info("Updated hook: " + label)
+	return report, nil
+}
+
+func (c *Client) RemoveGlobalHook(index int) (Report, error) {
+	return c.removeHook(index, true)
+}
+
+func (c *Client) hookList(global bool) (*SharedConfig, error) {
+	if global {
+		cfg, _, err := c.LoadGlobalSharedConfig()
+		return cfg, err
+	}
+	return c.LoadEffectiveSharedConfig()
+}
+
+func (c *Client) RemoveHookByID(id string, global bool) (Report, error) {
+	var report Report
+	cfg, err := c.hookList(global)
+	if err != nil {
+		return report, err
+	}
+	for i, hook := range cfg.Hooks {
+		if hook.ID == id {
+			return c.removeHook(i, global)
+		}
+	}
+	return report, fmt.Errorf("hook id not found: %s", id)
+}
+
+func (c *Client) removeHook(index int, global bool) (Report, error) {
+	var report Report
+	visible, err := c.hookList(global)
+	if err != nil {
+		return report, err
+	}
+	if index < 0 || index >= len(visible.Hooks) {
+		return report, fmt.Errorf("hook index out of range: %d", index+1)
+	}
+	removed := visible.Hooks[index]
+	cfg, configPath, err := c.loadSharedScope(global)
+	if err != nil {
+		return report, err
+	}
+	remaining := make([]Hook, 0, len(cfg.Hooks))
+	for _, hook := range cfg.Hooks {
+		if hookKey(hook) != hookKey(removed) {
+			remaining = append(remaining, hook)
+		}
+	}
+	if !global {
+		defaults, _, err := c.LoadGlobalSharedConfig()
+		if err != nil {
+			return report, err
+		}
+		for _, hook := range defaults.Hooks {
+			if hookKey(hook) == hookKey(removed) {
+				hook.Disabled = true
+				remaining = append(remaining, hook)
+				break
+			}
+		}
+	}
+	cfg.Hooks = remaining
+	if err := c.saveSharedScope(cfg, configPath, global); err != nil {
+		return report, err
+	}
+	report.Info(fmt.Sprintf("Removed or disabled hook: %d", index+1))
+	return report, nil
+}

--- a/internal/worktree/shared_paths.go
+++ b/internal/worktree/shared_paths.go
@@ -1,0 +1,255 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/samzong/gmc/internal/gitcmd"
+)
+
+func validateSharedPattern(pattern string) error {
+	if _, err := sanitizeTargetRelativePath(pattern); err != nil {
+		return err
+	}
+	for _, part := range strings.Split(filepath.ToSlash(pattern), "/") {
+		if part == ".git" || part == ".bare" || part == ".." {
+			return fmt.Errorf("shared path cannot address Git metadata or a parent directory: %s", pattern)
+		}
+		if part != "**" {
+			if _, err := path.Match(part, ""); err != nil {
+				return fmt.Errorf("invalid shared path pattern %q: %w", pattern, err)
+			}
+		}
+	}
+	return nil
+}
+
+func MatchSharedPath(pattern, candidate string) bool {
+	pattern = filepath.ToSlash(filepath.Clean(pattern))
+	candidate = filepath.ToSlash(filepath.Clean(candidate))
+	return matchSharedSegments(strings.Split(pattern, "/"), strings.Split(candidate, "/"))
+}
+
+func matchSharedSegments(pattern, candidate []string) bool {
+	if len(pattern) == 0 {
+		return len(candidate) == 0
+	}
+	if pattern[0] == "**" {
+		if matchSharedSegments(pattern[1:], candidate) {
+			return true
+		}
+		return len(candidate) > 0 && matchSharedSegments(pattern, candidate[1:])
+	}
+	if len(candidate) == 0 {
+		return false
+	}
+	matched, err := path.Match(pattern[0], candidate[0])
+	return err == nil && matched && matchSharedSegments(pattern[1:], candidate[1:])
+}
+
+func sharedRuleForPath(rules []SharedResource, candidate string, includeParents bool) (SharedResource, bool) {
+	var chosen SharedResource
+	found := false
+	for _, rule := range rules {
+		matches := MatchSharedPath(rule.Path, candidate)
+		if includeParents {
+			matches = matches || MatchSharedPath(strings.TrimSuffix(rule.Path, "/")+"/**", candidate)
+		}
+		if !matches {
+			continue
+		}
+		if !found || sharedRulePreferred(rule, chosen, candidate) {
+			chosen, found = rule, true
+		}
+	}
+	return chosen, found
+}
+
+func sharedRulePreferred(rule, previous SharedResource, candidate string) bool {
+	if (rule.Origin == "repository") != (previous.Origin == "repository") {
+		return rule.Origin == "repository"
+	}
+	if (rule.Path == candidate) != (previous.Path == candidate) {
+		return rule.Path == candidate
+	}
+	return len(rule.Path) >= len(previous.Path)
+}
+
+func sharedExcludedChild(rules []SharedResource, parent SharedResource, paths []string) string {
+	var candidates []string
+	for _, rule := range rules {
+		if rule.Disabled && !strings.ContainsAny(rule.Path, "*?[") {
+			candidates = append(candidates, rule.Path)
+		}
+	}
+	candidates = append(candidates, paths...)
+	for _, candidate := range candidates {
+		if !strings.HasPrefix(candidate, parent.Path+"/") {
+			continue
+		}
+		if rule, found := sharedRuleForPath(rules, candidate, true); found && rule.Disabled {
+			return rule.Path
+		}
+	}
+	return ""
+}
+
+func (c *Client) sharedSourceRoots() ([]string, error) {
+	if err := c.ensureInit(); err != nil {
+		return nil, err
+	}
+	var roots []string
+	seen := make(map[string]bool)
+	add := func(root string) {
+		if root == "" {
+			return
+		}
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		}
+		if info, err := os.Stat(root); err != nil || !info.IsDir() || seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	add(c.worktreeRoot)
+	if mainRoot, err := c.findMainWorktreePath(); err == nil {
+		add(mainRoot)
+	}
+	worktrees, err := c.ListCached()
+	if err != nil && len(roots) == 0 {
+		return nil, err
+	}
+	for _, wt := range worktrees {
+		if !wt.IsBare && filepath.Base(wt.Path) != ".bare" {
+			add(wt.Path)
+		}
+	}
+	return roots, nil
+}
+
+func (c *Client) primarySharedRoots(roots []string) []string {
+	if len(roots) > 0 {
+		if _, err := os.Lstat(filepath.Join(roots[0], ".git")); err == nil {
+			return roots[:1]
+		}
+	}
+	policy, err := c.NewProtectionPolicy()
+	if err != nil {
+		return nil
+	}
+	worktrees, err := c.ListCached()
+	if err != nil {
+		return nil
+	}
+	for _, wt := range worktrees {
+		if !wt.IsBare && policy.IsProtected(wt) {
+			if root, err := filepath.EvalSymlinks(wt.Path); err == nil {
+				return []string{root}
+			}
+		}
+	}
+	return nil
+}
+
+func sharedRuleUsesPrimary(rule SharedResource) bool {
+	return rule.Origin == "global" || strings.ContainsAny(rule.Path, "*?[")
+}
+
+func (c *Client) expandSharedResources(rules []SharedResource) ([]SharedResource, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	roots, err := c.sharedSourceRoots()
+	if err != nil {
+		return nil, err
+	}
+	paths := make(map[string]bool)
+	patterns := false
+	for _, rule := range rules {
+		if strings.ContainsAny(rule.Path, "*?[") {
+			patterns = true
+		} else {
+			paths[rule.Path] = true
+		}
+	}
+	if patterns {
+		for _, root := range c.primarySharedRoots(roots) {
+			entries, _, err := scanShareProjects(root, rules)
+			if err != nil {
+				return nil, err
+			}
+			for _, entry := range entries {
+				paths[entry.Path] = true
+			}
+		}
+	}
+	ordered := make([]string, 0, len(paths))
+	for resourcePath := range paths {
+		ordered = append(ordered, resourcePath)
+	}
+	sort.Strings(ordered)
+	var resources []SharedResource
+	for _, resourcePath := range ordered {
+		rule, found := sharedRuleForPath(rules, resourcePath, true)
+		if !found || rule.Disabled || !MatchSharedPath(rule.Path, resourcePath) {
+			continue
+		}
+		covered := false
+		for _, parent := range resources {
+			if strings.HasPrefix(resourcePath, parent.Path+"/") {
+				covered = true
+				break
+			}
+		}
+		if covered {
+			continue
+		}
+		rule.worktreeRelative = sharedRuleUsesPrimary(rule)
+		rule.Path = resourcePath
+		if excluded := sharedExcludedChild(rules, rule, ordered); excluded != "" {
+			return nil, fmt.Errorf("cannot exclude %s inside shared directory %s; "+
+				"disable the parent and share selected children", excluded, resourcePath)
+		}
+		resources = append(resources, rule)
+	}
+	return resources, nil
+}
+
+func ensureUntrackedResource(root, resourcePath string) error {
+	runner := gitcmd.Runner{Dir: root}
+	if _, err := runner.Run("rev-parse", "--show-toplevel"); err != nil {
+		if _, statErr := os.Lstat(filepath.Join(root, ".git")); os.IsNotExist(statErr) {
+			return nil
+		}
+		return fmt.Errorf("cannot inspect resource repository %s: %w", root, err)
+	}
+	result, err := runner.Run("--literal-pathspecs", "ls-files", "-z", "--", resourcePath)
+	if err != nil {
+		return fmt.Errorf("cannot inspect tracked resource %s: %w", resourcePath, err)
+	}
+	if len(result.Stdout) > 0 {
+		return fmt.Errorf("refusing to share Git-tracked content: %s", filepath.Join(root, resourcePath))
+	}
+	return nil
+}
+
+func ensureSharedDestination(root, relative string) error {
+	parent := filepath.Dir(relative)
+	for parent != "." {
+		info, err := os.Lstat(filepath.Join(root, parent))
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("shared destination has a symlink parent: %s", filepath.Join(root, parent))
+		}
+		parent = filepath.Dir(parent)
+	}
+	return nil
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -15,12 +15,14 @@ import (
 )
 
 type Options struct {
-	Verbose bool
+	Verbose          bool
+	GlobalConfigPath string
 }
 
 type Client struct {
-	runner  gitcmd.Runner
-	verbose bool
+	runner           gitcmd.Runner
+	verbose          bool
+	globalConfigPath string
 
 	once         sync.Once
 	bareRoot     string
@@ -36,8 +38,9 @@ type Client struct {
 
 func NewClient(opts Options) *Client {
 	return &Client{
-		runner:  gitcmd.Runner{Verbose: opts.Verbose},
-		verbose: opts.Verbose,
+		runner:           gitcmd.Runner{Verbose: opts.Verbose},
+		verbose:          opts.Verbose,
+		globalConfigPath: opts.GlobalConfigPath,
 	}
 }
 

--- a/website/content/docs/(worktree)/wt-hook.mdx
+++ b/website/content/docs/(worktree)/wt-hook.mdx
@@ -1,29 +1,57 @@
 ---
 title: Hooks
-description: Run commands after worktree creation.
+description: Run configured commands after shared resources are prepared.
 ---
 
-`gmc wt hook` manages commands that run after shared resources are synced into a new worktree.
+`gmc wt hook` manages commands run in a new worktree after [shared resources](./wt-share.mdx) are prepared. Use hooks for dependency installation, generated files, or repository setup. Adding a hook saves its configuration without executing it.
 
 ## Add a hook
 
 ```bash
-gmc wt hook add "pnpm install"
-gmc wt hook add "pnpm install && pnpm build" --desc "Install dependencies"
+gmc wt hook add "pnpm install" --id install --desc "Install dependencies"
+gmc wt hook add "test ! -f uv.lock || uv sync" --id python --global
 ```
 
-## List hooks
+Global hooks apply to every repository, so use explicit shell conditions for project-specific commands. Project discovery does not generate installation hooks or execute package managers.
+
+Give a hook a stable, nonnumeric `--id` without whitespace to replace or disable it in a repository. A repository hook with the same ID replaces the global command in its existing execution position. Additional repository hooks follow global hooks. Unnamed hooks are matched by their exact command text.
+
+## Configuration and order
+
+Global hooks live under `worktree.hooks` in the selected gmc config file, normally `~/.config/gmc/config.yaml`. `--config`, `GMC_CONFIG`, and existing XDG/legacy fallback rules select the file.
+
+```yaml
+worktree:
+  shared:
+    - path: .local
+      strategy: link
+  hooks:
+    - id: python
+      cmd: test ! -f uv.lock || uv sync
+```
+
+Repository overrides live alongside `shared` in `.git/gmc-share.yml` or `.bare/gmc-share.yml`, without the `worktree` wrapper. For example, disable an inherited hook:
+
+```yaml
+hooks:
+  - id: python
+    disabled: true
+```
+
+Enabled hooks run in effective list order in the target worktree directory. Sharing runs first, so an installation hook operates on any dependency directory that was explicitly linked. Existing resource targets are preserved; a hook may therefore encounter an existing independent directory instead of a requested link. `share discover` previews the resource and hook configuration together.
+
+`share discover` and `share sync` do not run hooks.
+
+## List and remove hooks
 
 ```bash
-gmc wt hook
+gmc wt hook list
+gmc wt hook list --global
+gmc wt hook list --output json
+gmc wt hook remove install
+gmc wt hook remove 1 --global
 ```
 
-## Remove a hook
+Running `gmc wt hook` also lists hooks. Lists show IDs, origins, disabled entries, and one-based indices. Use the index from the matching scope: effective list for repository removal, `list --global` for global removal.
 
-```bash
-gmc wt hook remove 1
-```
-
-## Notes
-
-Hooks are useful for dependency installation, generated files, or repo-local setup that every new worktree needs.
+Removing an inherited hook disables it only in the current repository. `--global` removes the default. Disabled entries remain visible in the effective list but are not executed.

--- a/website/content/docs/(worktree)/wt-share.mdx
+++ b/website/content/docs/(worktree)/wt-share.mdx
@@ -1,36 +1,79 @@
 ---
 title: Share Resources
-description: Share local files and directories across worktrees.
+description: Prepare local files and directories before worktree hooks run.
 ---
 
-`gmc wt share` manages resources that should be synced to every worktree.
+`gmc wt share` prepares files and directories in each repository's worktrees. Global defaults and repository rules use the same configuration as [hooks](./wt-hook.mdx).
 
 ## Add resources
 
 ```bash
-gmc wt share add .env
-gmc wt share add node_modules --strategy link
+gmc wt share add .env --strategy copy
+gmc wt share add .local --strategy link --global
+gmc wt share add '**/.local' --strategy link --global
 ```
 
-`copy` is the default strategy. Use it for secrets and local config. Use `link` for large identical directories.
+`copy` creates an independent copy. `link` creates a symlink to a shared writable source. Without `--strategy`, the command prompts for a strategy, defaulting to `copy`.
+
+`.local` is an example of a personal rule, not a built-in default. Quote patterns to prevent shell expansion; `**` matches nested paths. Scans skip dependency, build, and `.local` directory interiors. A directory share includes its whole contents; to exclude individual children, disable the parent rule and share selected children. Global and pattern rules always use worktree-relative paths from the primary worktree: the original checkout, or the protected main-branch worktree in a bare layout. If no primary worktree is available, automatic sharing waits for one. Directories found only in other worktrees remain visible in discovery but are not propagated by these rules. Existing worktree-relative sources take precedence over legacy worktree-name prefixes; legacy prefixes remain a fallback for repository rules.
+
+Adding a repository rule syncs its effective configuration to existing worktrees. Adding a global rule only saves the default; use `share sync` in a repository to apply it to existing worktrees. New worktrees apply effective rules before running configured hooks.
+
+## Global and repository configuration
+
+Global defaults live under `worktree` in the selected gmc config file, normally `~/.config/gmc/config.yaml`. The selection follows `--config`, `GMC_CONFIG`, and the existing XDG/legacy fallback rules.
+
+```yaml
+worktree:
+  shared:
+    - path: .local
+      strategy: link
+  hooks: []
+```
+
+Repository configuration stays in the Git common directory: `.git/gmc-share.yml` or `.bare/gmc-share.yml`. It uses `shared` and `hooks` at the top level, without a `worktree` wrapper. A repository rule overrides a global rule for the same path; `disabled: true` excludes an inherited resource.
+
+```yaml
+shared:
+  - path: .local
+    disabled: true
+```
+
+Global rules share resources within each repository, not between unrelated repositories. Global edits preserve unrelated settings in the selected config file.
 
 ## Discover
 
 ```bash
 gmc wt share discover
+gmc wt share discover --output json
 gmc wt share discover --auto
 ```
 
-Discovery previews likely shared resources unless `--auto` is used.
+Discovery scans repository worktrees for nested Node.js, Python, Go, and Rust projects, configuration files, and dependency or build directories. The text preview lists directories first, largest first, followed by files and unresolved paths. Sizes use KiB, MiB, or GiB; a `+` marks a partial scan. The sharing column describes configuration, while the current-state column shows what exists in this worktree.
+
+Project manifests and lockfiles contribute to the project summary instead of appearing as resource rows. The hook summary counts enabled and disabled hooks; use `gmc wt hook list` to inspect commands. `--output json` retains the full resource list, source paths, matched rules, guidance, project details, and hooks. Neither output format changes what `--auto` applies.
+
+- `candidate`: an untracked configuration file that can be copied.
+- `configured` or `excluded`: covered by an existing rule or exclusion, including parent-directory rules.
+- `managed`: a project, dependency environment, or build directory with ecosystem-specific guidance.
+- `tracked`: Git-tracked content that should remain in each checkout.
+
+Unconfigured `node_modules`, Python environments, and Rust build artifacts are informational results. Discovery does not automatically link them. Explicit sharing rules still apply; linking an environment lets installs in one branch change the dependencies seen by another.
+
+Sizes are logical file bytes, not exclusive physical usage or guaranteed savings. Existing hard links and copy-on-write storage can already reuse disk blocks. Incomplete size scans are marked as lower bounds.
+
+Without `--auto`, discovery only previews, including when `--dry-run=false` is passed. `--auto` adds eligible copy candidates and syncs effective rules, even if no new candidates were found. It cannot be combined with an explicit `--dry-run`. Neither discovery nor sync runs hooks or installs dependencies.
 
 ## List, remove, sync
 
 ```bash
 gmc wt share list
-gmc wt share remove .env
+gmc wt share list --global
+gmc wt share remove .local
+gmc wt share remove .local --global
 gmc wt share sync
 ```
 
-## Notes
+Lists show rule origins and disabled entries; `--output json` is also supported. Repository removal disables a matching inherited global rule. `--global` removes the default itself.
 
-The shared config lives in the repo's Git common directory, such as `.git/gmc-share.yml` or `.bare/gmc-share.yml`.
+Sync preserves existing target files, directories, and links, and reports conflicts. Adding a rule does not convert existing independent directories or reclaim their space. Removing a rule preserves existing files.


### PR DESCRIPTION
Worktree preparation previously required per-repository sharing rules, while discovery mixed configuration files with repeated project details. Add global preparation defaults and a directory-first discovery view.

- Store global `worktree.shared` and `worktree.hooks` defaults in the selected config file, with repository overrides, disabled entries, glob paths, and stable hook IDs. Preserve unrelated configuration with validated atomic writes.
- Apply sharing before configured creation hooks. Global and glob rules use the primary worktree as their source; discovery and sync never run hooks or install dependencies, and existing targets remain untouched.
- Detect nested Node.js, Python, Go, and Rust projects. Show directories by size, separate configured sharing from current state, and summarize project markers and hooks. JSON retains complete details. Dependency/build directories remain informational unless explicitly configured for sharing.

Validation: `make check`, `make build`, `make man`, and website MDX compilation passed. Native CLI probes cover global/repository overrides, exclusions, share-before-hook ordering, nonmutating previews, preserved targets, and configuration-write failure safety. Compared old/new discovery JSON for identical results while validating the compact terminal output.
