### PR TITLE
fix(worktree): default interactive share strategy to link

### DIFF
--- a/cmd/worktree_share.go
+++ b/cmd/worktree_share.go
@@ -402,13 +402,13 @@ func promptStrategy(reader *bufio.Reader) worktree.ResourceStrategy {
 	fmt.Fprintln(errWriter(), "\nStrategy:")
 	fmt.Fprintln(errWriter(), "  1. copy - each worktree gets its own copy")
 	fmt.Fprintln(errWriter(), "  2. link - symlink to shared source")
-	fmt.Fprint(errWriter(), "\nSelect [1/2, default: 1]: ")
+	fmt.Fprint(errWriter(), "\nSelect [1/2, default: 2]: ")
 	input, _ := reader.ReadString('\n')
 	input = strings.TrimSpace(strings.ToLower(input))
-	if input == "2" || input == "link" || input == "l" {
-		return worktree.StrategySymlink
+	if input == "1" || input == "copy" || input == "c" {
+		return worktree.StrategyCopy
 	}
-	return worktree.StrategyCopy
+	return worktree.StrategySymlink
 }
 
 func promptContinue(reader *bufio.Reader) {

--- a/website/content/docs/(worktree)/wt-share.mdx
+++ b/website/content/docs/(worktree)/wt-share.mdx
@@ -13,7 +13,7 @@ gmc wt share add .local --strategy link --global
 gmc wt share add '**/.local' --strategy link --global
 ```
 
-`copy` creates an independent copy. `link` creates a symlink to a shared writable source. Without `--strategy`, the command prompts for a strategy, defaulting to `copy`.
+`copy` creates an independent copy. `link` creates a symlink to a shared writable source. Without `--strategy`, the command prompts for a strategy, defaulting to `link`.
 
 `.local` is an example of a personal rule, not a built-in default. Quote patterns to prevent shell expansion; `**` matches nested paths. Scans skip dependency, build, and `.local` directory interiors. A directory share includes its whole contents; to exclude individual children, disable the parent rule and share selected children. Global and pattern rules always use worktree-relative paths from the primary worktree: the original checkout, or the protected main-branch worktree in a bare layout. If no primary worktree is available, automatic sharing waits for one. Directories found only in other worktrees remain visible in discovery but are not propagated by these rules. Existing worktree-relative sources take precedence over legacy worktree-name prefixes; legacy prefixes remain a fallback for repository rules.
 


### PR DESCRIPTION
### What's changed?

- Default the interactive `gmc wt share` add Strategy prompt to `link` (option 2 / Enter)
- Align the website docs with that prompt default

### Why

- `link` is the common choice when adding shared resources interactively