### PR TITLE
feat(worktree): cache Rust dependencies in new worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ go install github.com/samzong/gmc@latest
 | `gmc --output json` | Machine-readable output for agents and CI |
 | `gmc completion zsh\|bash\|fish` | Shell completion |
 
+## Rust dependency cache
+
+New Rust worktrees automatically cache dependencies with [Kache](https://github.com/kunobi-ninja/kache).
+Keep using the same gmc and Cargo commands; no separate installation or configuration is required.
+Packages selected by Cargo retain native incremental compilation, and each worktree keeps its own target directory.
+
+Setup requires a root `Cargo.toml` and skips existing `.cargo` directories or compiler wrappers.
+It adds ignored local Cargo configuration without changing global configuration or tracked files.
+The first eligible creation downloads a pinned, checksum-verified Kache release. Tools and a local
+cache capped at 10 GiB live under `${XDG_DATA_HOME:-~/.local/share}/gmc/rust-cache`.
+Unavailable setup leaves normal Cargo builds available; diagnostics use gmc's existing `--debug` flag.
+
 ## Config
 
 Config lives at `~/.config/gmc/config.yaml` (legacy `~/.gmc.yaml` still works; a project-level `.gmc.yaml` overrides global). Run `gmc init` for a guided setup, or set fields manually:

--- a/cmd/worktree_client.go
+++ b/cmd/worktree_client.go
@@ -6,5 +6,5 @@ import (
 )
 
 func newWorktreeClient() *worktree.Client {
-	return worktree.NewClient(worktree.Options{Verbose: verbose, GlobalConfigPath: config.FilePath()})
+	return worktree.NewClient(worktree.Options{Verbose: verbose || debug, GlobalConfigPath: config.FilePath()})
 }

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/spf13/afero v1.15.0 // indirect

--- a/internal/rustcache/config.go
+++ b/internal/rustcache/config.go
@@ -1,0 +1,135 @@
+package rustcache
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+const ignoreContent = "/config.toml\n/.gitignore\n"
+
+func Eligible(root string) (bool, string) {
+	info, err := os.Lstat(filepath.Join(root, "Cargo.toml"))
+	if err != nil || !info.Mode().IsRegular() {
+		return false, ""
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".cargo")); !errors.Is(err, os.ErrNotExist) {
+		return false, "existing .cargo directory or file"
+	}
+	for _, key := range []string{
+		"RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "CARGO_BUILD_RUSTC_WRAPPER", "CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER",
+	} {
+		if _, ok := os.LookupEnv(key); ok {
+			return false, "existing " + key
+		}
+	}
+	dirs := []string{}
+	for dir := filepath.Dir(root); ; dir = filepath.Dir(dir) {
+		dirs = append(dirs, filepath.Join(dir, ".cargo"))
+		if filepath.Dir(dir) == dir {
+			break
+		}
+	}
+	home := os.Getenv("CARGO_HOME")
+	if home != "" && !filepath.IsAbs(home) {
+		return false, "relative CARGO_HOME"
+	}
+	if home == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return false, "cannot resolve Cargo home"
+		}
+		home = filepath.Join(userHome, ".cargo")
+	}
+	dirs = append(dirs, home)
+	for _, dir := range dirs {
+		for _, name := range []string{"config", "config.toml"} {
+			path := filepath.Join(dir, name)
+			info, err := os.Lstat(path)
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			if err != nil || !info.Mode().IsRegular() || info.Size() > 1<<20 {
+				return false, "cannot inspect inherited Cargo configuration"
+			}
+			data, err := os.ReadFile(path)
+			var cfg map[string]any
+			if err != nil || toml.Unmarshal(data, &cfg) != nil {
+				return false, "cannot inspect inherited Cargo configuration"
+			}
+			if _, ok := cfg["include"]; ok {
+				return false, "inherited Cargo configuration includes other files"
+			}
+			if build, ok := cfg["build"].(map[string]any); ok {
+				for _, key := range []string{"rustc-wrapper", "rustc-workspace-wrapper"} {
+					if _, ok := build[key]; ok {
+						return false, "inherited Cargo " + key
+					}
+				}
+			}
+		}
+	}
+	return true, ""
+}
+
+func Enable(root, helper string) error {
+	data, err := toml.Marshal(map[string]any{"build": map[string]string{"rustc-wrapper": helper}})
+	if err != nil {
+		return err
+	}
+	cargo := filepath.Join(root, ".cargo")
+	if err := os.Mkdir(cargo, 0755); err != nil {
+		return err
+	}
+	configPath := filepath.Join(cargo, "config.toml")
+	if err := exclusiveWrite(configPath, data); err != nil {
+		_ = os.Remove(cargo)
+		return err
+	}
+	if err := exclusiveWrite(filepath.Join(cargo, ".gitignore"), []byte(ignoreContent)); err != nil {
+		_ = removeMatching(configPath, data)
+		_ = os.Remove(cargo)
+		return err
+	}
+	return nil
+}
+
+func exclusiveWrite(path string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.Write(data)
+	if err := errors.Join(writeErr, file.Close()); err != nil {
+		return errors.Join(err, os.Remove(path))
+	}
+	return nil
+}
+
+func removeMatching(path string, expected []byte) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("kept changed %s; remove the gmc cache configuration manually", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(data, expected) {
+		return fmt.Errorf("kept edited %s; remove the gmc cache configuration manually", path)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/rustcache/config_test.go
+++ b/internal/rustcache/config_test.go
@@ -1,0 +1,69 @@
+package rustcache
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurationPreservesExistingFiles(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, Enable(root, "/tools/gmc-rustc"))
+	config := filepath.Join(root, ".cargo", "config.toml")
+	changed := []byte("[build]\njobs = 2\n")
+	require.NoError(t, os.WriteFile(config, changed, 0600))
+	require.Error(t, Enable(root, "/tools/new-gmc-rustc"))
+	actual, err := os.ReadFile(config)
+	require.NoError(t, err)
+	require.Equal(t, changed, actual)
+}
+
+func TestInheritedWrapperPreventsInstallation(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "project")
+	require.NoError(t, os.Mkdir(root, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte("[package]\n"), 0600))
+	t.Setenv("CARGO_HOME", t.TempDir())
+	eligible, reason := Eligible(root)
+	require.True(t, eligible, reason)
+	require.NoError(t, os.Mkdir(filepath.Join(parent, ".cargo"), 0755))
+	path := filepath.Join(parent, ".cargo", "config.toml")
+	for _, content := range []string{
+		"[build]\nrustc-wrapper = ''\n", "[build]\nrustc-workspace-wrapper = 'custom'\n", "include = ['other.toml']\n",
+	} {
+		require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+		eligible, _ = Eligible(root)
+		require.False(t, eligible)
+	}
+	require.NoError(t, os.Remove(path))
+	t.Setenv("RUSTC_WRAPPER", "")
+	eligible, _ = Eligible(root)
+	require.False(t, eligible)
+}
+
+func TestReleaseIntegrityAndExtraction(t *testing.T) {
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	tarWriter := tar.NewWriter(gz)
+	contents := []byte("verified binary")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{Name: "release/kache", Mode: 0755, Size: int64(len(contents))}))
+	_, err := tarWriter.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gz.Close())
+	r := release{name: "release.tar.gz", sha: fmt.Sprintf("%x", sha256.Sum256(compressed.Bytes()))}
+	got, err := releaseBinary(compressed.Bytes(), r)
+	require.NoError(t, err)
+	require.Equal(t, contents, got)
+	corrupt := append([]byte{}, compressed.Bytes()...)
+	corrupt[len(corrupt)-1] ^= 1
+	_, err = releaseBinary(corrupt, r)
+	require.Error(t, err)
+}

--- a/internal/rustcache/config_unix_test.go
+++ b/internal/rustcache/config_unix_test.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package rustcache
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExclusiveWriteFailure(t *testing.T) {
+	if path := os.Getenv("GMC_TEST_WRITE_LIMIT"); path != "" {
+		signal.Ignore(syscall.SIGXFSZ)
+		var previous syscall.Rlimit
+		require.NoError(t, syscall.Getrlimit(syscall.RLIMIT_FSIZE, &previous))
+		defer func() { require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_FSIZE, &previous)) }()
+		limit := previous
+		limit.Cur = 512
+		require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_FSIZE, &limit))
+		require.Error(t, exclusiveWrite(path, bytes.Repeat([]byte("x"), 4096)))
+		require.NoFileExists(t, path)
+		return
+	}
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	command := exec.Command(exe, "-test.run=^TestExclusiveWriteFailure$")
+	command.Env = append(os.Environ(), "GMC_TEST_WRITE_LIMIT="+filepath.Join(t.TempDir(), "state"))
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+}

--- a/internal/rustcache/execute_unix.go
+++ b/internal/rustcache/execute_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package rustcache
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func execute(args, env []string) error {
+	path, err := exec.LookPath(args[0])
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(path, args, env)
+}

--- a/internal/rustcache/execute_windows.go
+++ b/internal/rustcache/execute_windows.go
@@ -1,0 +1,13 @@
+package rustcache
+
+import (
+	"os"
+	"os/exec"
+)
+
+func execute(args, env []string) error {
+	command := exec.Command(args[0], args[1:]...)
+	command.Env = env
+	command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return command.Run()
+}

--- a/internal/rustcache/install.go
+++ b/internal/rustcache/install.go
@@ -1,0 +1,174 @@
+package rustcache
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const Version = "0.18.0"
+
+type release struct {
+	name string
+	sha  string
+}
+
+var releases = map[string]release{
+	"darwin/arm64": {
+		"kache-aarch64-apple-darwin.tar.gz",
+		"48decca430d16cb84a9cd055f7a352e35b3d8d18bace646be8eda734f516ea74",
+	},
+	"darwin/amd64": {
+		"kache-x86_64-apple-darwin.tar.gz",
+		"c96eef46bec2999d8c7393e04452926d2b3f66bebef4ff485b115c6e8fafa363",
+	},
+	"linux/arm64": {
+		"kache-aarch64-unknown-linux-musl.tar.gz",
+		"0a895ca560e17cdbf00c596a67c6af54baa907a95fac4d6cd04adb66268d7434",
+	},
+	"linux/amd64": {
+		"kache-x86_64-unknown-linux-musl.tar.gz",
+		"2209e1e4de2c49a3a732a6ba86ad9ad4502c5cdc139b53723aa1e6c33efd8662",
+	},
+	"windows/amd64": {
+		"kache-x86_64-pc-windows-msvc.exe",
+		"10b84a60e533bd58ba56cdb421f6b722f5d589aeacf8a37d9c7fa3c8b69c5d9c",
+	},
+}
+
+func executableName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+func Ensure() (string, error) {
+	r, ok := releases[runtime.GOOS+"/"+runtime.GOARCH]
+	if !ok {
+		return "", errors.New("kache is unavailable for this platform")
+	}
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	root, err := filepath.Abs(filepath.Join(dataHome, "gmc", "rust-cache"))
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(root, "kache-"+Version+"-"+runtime.GOOS+"-"+runtime.GOARCH)
+	backend := filepath.Join(dir, executableName("kache"))
+	if info, statErr := os.Lstat(backend); statErr != nil || !info.Mode().IsRegular() {
+		if err := installRelease(dir, r); err != nil {
+			return "", err
+		}
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(exe)
+	if err != nil {
+		return "", err
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256(data))
+	helperDir := filepath.Join(dir, "adapter-"+hash)
+	if err := os.MkdirAll(helperDir, 0700); err != nil {
+		return "", err
+	}
+	helper := filepath.Join(helperDir, executableName("gmc-rustc"))
+	if _, err := os.Lstat(helper); errors.Is(err, os.ErrNotExist) {
+		if err := atomicWrite(helper, data, 0755); err != nil {
+			return "", err
+		}
+	} else if err != nil {
+		return "", err
+	}
+	return helper, nil
+}
+
+func installRelease(dir string, r release) error {
+	client := http.Client{Timeout: 30 * time.Second}
+	url := "https://github.com/kunobi-ninja/kache/releases/download/v" + Version + "/" + r.name
+	response, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("download Kache: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("download Kache: HTTP %d", response.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, 32<<20))
+	if err != nil {
+		return err
+	}
+	binary, err := releaseBinary(data, r)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	if err := atomicWrite(filepath.Join(dir, "config.toml"), []byte("[cache]\n"), 0600); err != nil {
+		return err
+	}
+	return atomicWrite(filepath.Join(dir, executableName("kache")), binary, 0755)
+}
+
+func releaseBinary(data []byte, r release) ([]byte, error) {
+	if fmt.Sprintf("%x", sha256.Sum256(data)) != r.sha {
+		return nil, errors.New("kache download checksum mismatch")
+	}
+	if strings.HasSuffix(r.name, ".exe") {
+		return data, nil
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	archive := tar.NewReader(reader)
+	for {
+		header, err := archive.Next()
+		if err != nil {
+			return nil, fmt.Errorf("read Kache archive: %w", err)
+		}
+		if filepath.Base(header.Name) == "kache" && header.Typeflag == tar.TypeReg {
+			if header.Size < 1 || header.Size > 64<<20 {
+				return nil, errors.New("invalid Kache binary size")
+			}
+			return io.ReadAll(archive)
+		}
+	}
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	file, err := os.CreateTemp(filepath.Dir(path), ".gmc-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+	_, writeErr := file.Write(data)
+	closeErr := file.Close()
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		return err
+	}
+	if err := os.Chmod(file.Name(), mode); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), path)
+}

--- a/internal/rustcache/wrapper.go
+++ b/internal/rustcache/wrapper.go
@@ -1,0 +1,53 @@
+package rustcache
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func IsWrapper() bool {
+	return filepath.Base(os.Args[0]) == executableName("gmc-rustc")
+}
+
+func RunWrapper(args []string) error {
+	if len(args) == 0 {
+		return errors.New("missing rustc executable")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(filepath.Dir(exe))
+	backend := filepath.Join(dir, executableName("kache"))
+	_, primary := os.LookupEnv("CARGO_PRIMARY_PACKAGE")
+	if primary {
+		return execute(args, os.Environ())
+	}
+	if info, err := os.Stat(backend); err != nil || !info.Mode().IsRegular() {
+		return execute(args, os.Environ())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.toml")); err != nil {
+		return execute(args, os.Environ())
+	}
+	env := make([]string, 0, len(os.Environ())+5)
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		if !strings.HasPrefix(strings.ToUpper(key), "KACHE_") {
+			env = append(env, value)
+		}
+	}
+	env = append(env,
+		"KACHE_CONFIG="+filepath.Join(dir, "config.toml"),
+		"KACHE_CACHE_DIR="+filepath.Join(dir, "store"),
+		"KACHE_RUNTIME_DIR="+filepath.Join(dir, "runtime"),
+		"KACHE_MAX_SIZE=10GiB", "KACHE_DAEMON_IDLE_TIMEOUT=60")
+	err = execute(append([]string{backend}, args...), env)
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		return execute(args, os.Environ())
+	}
+	return err
+}

--- a/internal/rustcache/wrapper_test.go
+++ b/internal/rustcache/wrapper_test.go
@@ -1,0 +1,61 @@
+package rustcache
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapperExecution(t *testing.T) {
+	if os.Getenv("GMC_WRAPPER_TEST_CHILD") == "1" {
+		err := RunWrapper([]string{os.Getenv("GMC_WRAPPER_TEST_COMPILER"), "argument with spaces"})
+		require.NoError(t, err)
+		return
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix process replacement and executable fixture")
+	}
+	root := t.TempDir()
+	adapter := filepath.Join(root, "adapter")
+	require.NoError(t, os.Mkdir(adapter, 0700))
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	data, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	helper := filepath.Join(adapter, "test-wrapper")
+	require.NoError(t, os.WriteFile(helper, data, 0755))
+	compiler := filepath.Join(root, "rustc")
+	require.NoError(t, os.WriteFile(compiler, []byte("#!/bin/sh\nprintf 'native:%s' \"$1\"\n"), 0755))
+	backend := filepath.Join(root, "kache")
+	script := "#!/bin/sh\nprintf 'cache:%s:%s:%s' " +
+		"\"${KACHE_REMOTE_ENDPOINT-unset}\" \"${kache_remote_endpoint-unset}\" \"$2\"\nexit 7\n"
+	require.NoError(t, os.WriteFile(backend, []byte(script), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "config.toml"), nil, 0600))
+	t.Setenv("GMC_WRAPPER_TEST_CHILD", "1")
+	t.Setenv("GMC_WRAPPER_TEST_COMPILER", compiler)
+	t.Setenv("KACHE_REMOTE_ENDPOINT", "must-not-reach-backend")
+	t.Setenv("kache_remote_endpoint", "must-not-reach-backend")
+	command := func() *exec.Cmd { return exec.Command(helper, "-test.run=^TestWrapperExecution$") }
+	out, err := command().CombinedOutput()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 7, exitErr.ExitCode())
+	require.Equal(t, "cache:unset:unset:argument with spaces", string(out))
+	require.NoError(t, os.Remove(backend))
+	out, err = command().CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, "native:argument with spaces", string(out))
+	require.NoError(t, os.WriteFile(backend, []byte(script), 0644))
+	out, err = command().CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, "native:argument with spaces", string(out))
+	require.NoError(t, os.Chmod(backend, 0755))
+	t.Setenv("CARGO_PRIMARY_PACKAGE", "1")
+	out, err = command().CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, "native:argument with spaces", string(out))
+}

--- a/internal/worktree/bare.go
+++ b/internal/worktree/bare.go
@@ -73,6 +73,7 @@ func (c *Client) Clone(repoURL string, opts CloneOptions) (Report, error) {
 		os.RemoveAll(projectName)
 		return report, err
 	}
+	c.prepareRustCache(mainWorktree, &report)
 
 	report.Info("")
 	report.Info(fmt.Sprintf("Successfully cloned to %s/", projectName))

--- a/internal/worktree/pr.go
+++ b/internal/worktree/pr.go
@@ -109,7 +109,7 @@ func (c *Client) AddPR(prNumber int, remote string) (Report, error) {
 		return report, err
 	}
 
-	sharedReport, err := c.syncSharedResourcesToPath(ctx.targetPath, true)
+	sharedReport, err := c.prepareNewWorktree(ctx.targetPath)
 	report.Merge(sharedReport)
 	if err != nil {
 		report.Warn(fmt.Sprintf("Warning: failed to sync shared resources: %v", err))

--- a/internal/worktree/resource.go
+++ b/internal/worktree/resource.go
@@ -58,6 +58,14 @@ func (c *Client) SyncSharedResources(worktreeName string) (Report, error) {
 }
 
 func (c *Client) syncSharedResourcesToPath(targetRoot string, runHooks bool) (Report, error) {
+	return c.syncWorktreeResources(targetRoot, runHooks, false)
+}
+
+func (c *Client) prepareNewWorktree(targetRoot string) (Report, error) {
+	return c.syncWorktreeResources(targetRoot, true, true)
+}
+
+func (c *Client) syncWorktreeResources(targetRoot string, runHooks, prepare bool) (Report, error) {
 	var report Report
 
 	cfg, err := c.LoadEffectiveSharedConfig()
@@ -65,7 +73,7 @@ func (c *Client) syncSharedResourcesToPath(targetRoot string, runHooks bool) (Re
 		return report, err
 	}
 
-	if len(cfg.Resources) == 0 && (!runHooks || len(cfg.Hooks) == 0) {
+	if !prepare && len(cfg.Resources) == 0 && (!runHooks || len(cfg.Hooks) == 0) {
 		return report, nil
 	}
 
@@ -85,6 +93,9 @@ func (c *Client) syncSharedResourcesToPath(targetRoot string, runHooks bool) (Re
 		}
 	}
 
+	if prepare {
+		c.prepareRustCache(targetRoot, &report)
+	}
 	if runHooks {
 		if err := c.runHooks(targetRoot, cfg.Hooks, &report); err != nil {
 			return report, err

--- a/internal/worktree/rust_cache.go
+++ b/internal/worktree/rust_cache.go
@@ -1,0 +1,27 @@
+package worktree
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/samzong/gmc/internal/rustcache"
+)
+
+var ensureRustCache = sync.OnceValues(rustcache.Ensure)
+
+func (c *Client) prepareRustCache(root string, report *Report) {
+	eligible, reason := rustcache.Eligible(root)
+	if !eligible {
+		if c.verbose && reason != "" {
+			report.Info("Rust cache skipped: " + reason)
+		}
+		return
+	}
+	helper, err := ensureRustCache()
+	if err == nil {
+		err = rustcache.Enable(root, helper)
+	}
+	if c.verbose && err != nil {
+		report.Warn(fmt.Sprintf("Rust cache skipped: %v", err))
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -379,7 +379,7 @@ func (c *Client) Add(name string, opts AddOptions) (Report, error) {
 		return report, err
 	}
 
-	sharedReport, err := c.syncSharedResourcesToPath(ctx.targetPath, true)
+	sharedReport, err := c.prepareNewWorktree(ctx.targetPath)
 	report.Merge(sharedReport)
 	if err != nil {
 		report.Warn(fmt.Sprintf("Warning: failed to sync shared resources: %v", err))
@@ -857,7 +857,7 @@ func (c *Client) Dup(opts DupOptions) (*DupResult, error) {
 			return nil, err
 		}
 
-		sharedReport, err := c.syncSharedResourcesToPath(targetPath, true)
+		sharedReport, err := c.prepareNewWorktree(targetPath)
 		if err != nil {
 			dupResult.Warnings = append(
 				dupResult.Warnings,

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -9,7 +9,34 @@ import (
 	"testing"
 
 	"github.com/samzong/gmc/internal/gitutil"
+	"github.com/stretchr/testify/require"
 )
+
+func TestRustCacheCreation(t *testing.T) {
+	t.Setenv("CARGO_HOME", t.TempDir())
+	repo := initTestRepo(t)
+	t.Chdir(repo)
+	writeFile(t, filepath.Join(repo, "Cargo.toml"), "[package]\nname = 'test'\nversion = '0.1.0'\n")
+	runGit(t, repo, "add", "Cargo.toml")
+	runGit(t, repo, "commit", "-m", "Add Rust package")
+	previous := ensureRustCache
+	helper := filepath.Join(t.TempDir(), "gmc-rustc")
+	ensureRustCache = func() (string, error) {
+		return helper, os.WriteFile(helper, []byte("test adapter"), 0755)
+	}
+	t.Cleanup(func() { ensureRustCache = previous })
+	client := NewClient(Options{})
+	_, err := client.Add("cache-test", AddOptions{})
+	require.NoError(t, err)
+	target := repo + "--cache-test"
+	t.Cleanup(func() {
+		_, err := client.Remove(target, RemoveOptions{Force: true, DeleteBranch: true})
+		require.NoError(t, err)
+	})
+	require.FileExists(t, filepath.Join(target, ".cargo", "config.toml"))
+	require.Empty(t, runGit(t, target, "status", "--porcelain"))
+	require.NoDirExists(t, filepath.Join(repo, ".cargo"))
+}
 
 func TestRepoTypeString(t *testing.T) {
 	tests := []struct {

--- a/main.go
+++ b/main.go
@@ -2,13 +2,27 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/samzong/gmc/cmd"
 	"github.com/samzong/gmc/internal/exitcode"
+	"github.com/samzong/gmc/internal/rustcache"
 )
 
 func main() {
+	if rustcache.IsWrapper() {
+		if err := rustcache.RunWrapper(os.Args[1:]); err != nil {
+			var processErr *exec.ExitError
+			if errors.As(err, &processErr) {
+				os.Exit(processErr.ExitCode())
+			}
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
 	if err := cmd.Execute(); err != nil {
 		var exitErr *exitcode.Error
 		if errors.As(err, &exitErr) {


### PR DESCRIPTION
### What's changed?

- Automatically prepare a pinned, checksum-verified Kache installation for eligible new Rust worktrees.
- Cache dependency compilation while keeping Cargo-selected packages on native incremental compilation and preserving separate target directories.
- Preserve existing Cargo configuration and compiler wrappers; skip unavailable setup without blocking worktree creation.

### Why

- Reuse dependency compilation across worktrees without extra commands or manual cache setup.

### Verification

- `make check`
- `make build`
- `go test -race ./internal/rustcache ./internal/worktree ./cmd`
- Real Cargo build, check, and test in fresh worktrees on macOS arm64; verified clean Git status, existing configuration preservation, and native compilation when the cache backend is missing.
