### PR TITLE
fix(worktree): discover nested rust projects for caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ New Rust worktrees automatically cache dependencies with [Kache](https://github.
 Keep using the same gmc and Cargo commands; no separate installation or configuration is required.
 Packages selected by Cargo retain native incremental compilation, and each worktree keeps its own target directory.
 
-Setup requires a root `Cargo.toml` and skips existing `.cargo` directories or compiler wrappers.
+Setup discovers root and nested `Cargo.toml` files, including multiple Rust projects in a monorepo.
+Parent Rust roots cover their descendants; existing `.cargo` directories or compiler wrappers are preserved.
+Dependency/build directories, symbolic links, and nested Git repositories are excluded from discovery.
 It adds ignored local Cargo configuration without changing global configuration or tracked files.
 The first eligible creation downloads a pinned, checksum-verified Kache release. Tools and a local
 cache capped at 10 GiB live under `${XDG_DATA_HOME:-~/.local/share}/gmc/rust-cache`.

--- a/internal/worktree/rust_cache.go
+++ b/internal/worktree/rust_cache.go
@@ -2,6 +2,9 @@ package worktree
 
 import (
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/samzong/gmc/internal/rustcache"
@@ -10,18 +13,44 @@ import (
 var ensureRustCache = sync.OnceValues(rustcache.Ensure)
 
 func (c *Client) prepareRustCache(root string, report *Report) {
-	eligible, reason := rustcache.Eligible(root)
-	if !eligible {
-		if c.verbose && reason != "" {
-			report.Info("Rust cache skipped: " + reason)
+	_, projects, err := scanShareProjects(root, nil)
+	if err != nil {
+		if c.verbose {
+			report.Warn(fmt.Sprintf("Rust cache discovery skipped: %v", err))
 		}
 		return
 	}
-	helper, err := ensureRustCache()
-	if err == nil {
-		err = rustcache.Enable(root, helper)
-	}
-	if c.verbose && err != nil {
-		report.Warn(fmt.Sprintf("Rust cache skipped: %v", err))
+	sort.Slice(projects, func(i, j int) bool { return len(projects[i].Path) < len(projects[j].Path) })
+	var roots []string
+	for _, project := range projects {
+		if project.Ecosystem != "Rust" || filepath.Base(project.Path) != "Cargo.toml" {
+			continue
+		}
+		covered := false
+		for _, parent := range roots {
+			if parent == "." || strings.HasPrefix(project.Project, parent+"/") {
+				covered = true
+				break
+			}
+		}
+		if covered {
+			continue
+		}
+		roots = append(roots, project.Project)
+		path := filepath.Join(root, filepath.FromSlash(project.Project))
+		eligible, reason := rustcache.Eligible(path)
+		if !eligible {
+			if c.verbose && reason != "" {
+				report.Info(fmt.Sprintf("Rust cache skipped (%s): %s", project.Project, reason))
+			}
+			continue
+		}
+		helper, err := ensureRustCache()
+		if err == nil {
+			err = rustcache.Enable(path, helper)
+		}
+		if c.verbose && err != nil {
+			report.Warn(fmt.Sprintf("Rust cache skipped (%s): %v", project.Project, err))
+		}
 	}
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -13,29 +13,59 @@ import (
 )
 
 func TestRustCacheCreation(t *testing.T) {
-	t.Setenv("CARGO_HOME", t.TempDir())
-	repo := initTestRepo(t)
-	t.Chdir(repo)
-	writeFile(t, filepath.Join(repo, "Cargo.toml"), "[package]\nname = 'test'\nversion = '0.1.0'\n")
-	runGit(t, repo, "add", "Cargo.toml")
-	runGit(t, repo, "commit", "-m", "Add Rust package")
-	previous := ensureRustCache
-	helper := filepath.Join(t.TempDir(), "gmc-rustc")
-	ensureRustCache = func() (string, error) {
-		return helper, os.WriteFile(helper, []byte("test adapter"), 0755)
+	for _, nested := range []bool{false, true} {
+		t.Run(fmt.Sprintf("nested=%t", nested), func(t *testing.T) {
+			t.Setenv("CARGO_HOME", t.TempDir())
+			repo := initTestRepo(t)
+			t.Chdir(repo)
+			roots := []string{"."}
+			if nested {
+				roots = []string{"apps/gateway", "tools/worker"}
+			}
+			for _, root := range roots {
+				require.NoError(t, os.MkdirAll(filepath.Join(repo, root, "!child"), 0755))
+				writeFile(t, filepath.Join(repo, root, "Cargo.toml"), "[workspace]\nmembers = ['!child']\n")
+				writeFile(t, filepath.Join(repo, root, "!child", "Cargo.toml"), "[package]\nname = 'member'\nversion = '0.1.0'\n")
+			}
+			if nested {
+				require.NoError(t, os.MkdirAll(filepath.Join(repo, "custom", ".cargo"), 0755))
+				require.NoError(t, os.MkdirAll(filepath.Join(repo, "target", "fixture"), 0755))
+				writeFile(t, filepath.Join(repo, "custom", "Cargo.toml"), "[workspace]\n")
+				writeFile(t, filepath.Join(repo, "custom", ".cargo", "config.toml"), "[build]\njobs = 2\n")
+				writeFile(t, filepath.Join(repo, "target", "fixture", "Cargo.toml"), "[workspace]\n")
+			}
+			runGit(t, repo, "add", ".")
+			runGit(t, repo, "commit", "-m", "Add Rust package")
+			previous := ensureRustCache
+			helper := filepath.Join(t.TempDir(), "gmc-rustc")
+			ensureRustCache = func() (string, error) {
+				return helper, os.WriteFile(helper, []byte("test adapter"), 0755)
+			}
+			t.Cleanup(func() { ensureRustCache = previous })
+			client := NewClient(Options{})
+			_, err := client.Add("cache-test", AddOptions{})
+			require.NoError(t, err)
+			target := repo + "--cache-test"
+			t.Cleanup(func() {
+				_, err := client.Remove(target, RemoveOptions{Force: true, DeleteBranch: true})
+				require.NoError(t, err)
+			})
+			for _, root := range roots {
+				require.FileExists(t, filepath.Join(target, root, ".cargo", "config.toml"))
+				require.NoDirExists(t, filepath.Join(target, root, "!child", ".cargo"))
+				require.NoDirExists(t, filepath.Join(repo, root, ".cargo"))
+			}
+			if nested {
+				data, err := os.ReadFile(filepath.Join(target, "custom", ".cargo", "config.toml"))
+				require.NoError(t, err)
+				require.Equal(t, "[build]\njobs = 2\n", string(data))
+				require.NoDirExists(t, filepath.Join(target, "target", "fixture", ".cargo"))
+				require.NoDirExists(t, filepath.Join(target, ".cargo"))
+			}
+			require.Empty(t, runGit(t, target, "status", "--porcelain"))
+			require.NoDirExists(t, filepath.Join(repo, ".cargo"))
+		})
 	}
-	t.Cleanup(func() { ensureRustCache = previous })
-	client := NewClient(Options{})
-	_, err := client.Add("cache-test", AddOptions{})
-	require.NoError(t, err)
-	target := repo + "--cache-test"
-	t.Cleanup(func() {
-		_, err := client.Remove(target, RemoveOptions{Force: true, DeleteBranch: true})
-		require.NoError(t, err)
-	})
-	require.FileExists(t, filepath.Join(target, ".cargo", "config.toml"))
-	require.Empty(t, runGit(t, target, "status", "--porcelain"))
-	require.NoDirExists(t, filepath.Join(repo, ".cargo"))
 }
 
 func TestRepoTypeString(t *testing.T) {


### PR DESCRIPTION
### What's changed?

- Discover nested Cargo projects when preparing new worktrees, so monorepos without a root Cargo.toml receive dependency caching.
- Configure independent Rust roots separately and process ancestors first to avoid redundant descendant configuration.
- Reuse existing project discovery exclusions and preserve existing Cargo configuration and compiler wrappers.

### Why

- Root-only detection skipped Rust services inside mixed-language repositories.

### Verification

- `make check`
- `make build`
- `go test -race ./internal/rustcache ./internal/worktree`
- Worktree creation regression covering multiple nested roots, ancestor ordering, existing configuration preservation, and excluded build directories.
- Real offline Cargo tests from the roots and member directories of two independent workspaces, using a passthrough compiler wrapper to verify configuration compatibility.
